### PR TITLE
[URGENT] Render extension responses safely

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-12
 
+- Replaced extension `innerHTML` sinks with text-only DOM rendering, restricted
+  source links to HTTP(S), isolated new tabs, and added canonical regressions.
 - Replaced raw DynamoDB query partition keys with namespaced SHA-256 identities
   so accepted long and Unicode queries remain within storage key limits.
 - Added deterministic, fixed-size, plaintext-absence, read/write symmetry, and

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ make verify
 unit tests without live OpenAI, Pinecone, AWS, or Twilio credentials, and
 `make build` compiles the Chalice app and helper modules. `make verify` keeps
 the existing combined gate across tests, compile checks, and the source
-baseline.
+baseline. The baseline also syntax-checks both extension bundles and verifies
+that remote content uses text-only rendering with HTTP(S)-only source links.
 GitHub Actions installs the pinned API requirements on Python 3.10, verifies
 dependency consistency, checks out without persisting the workflow token, and
 runs the same offline `make check` baseline.
@@ -111,6 +112,9 @@ When the required SDK or runtime is unavailable, use static checks and source re
   metadata cannot expand generated-answer prompts without bound.
 - Keep unexpected route failures logged server-side while callers receive
   generic 500 errors.
+- Keep user queries and model responses on text-only DOM rendering in both
+  extension bundles. Source links must be HTTP(S)-only and use opener
+  isolation when opened in a new tab.
 - Review changes touching network requests, sockets, or service endpoints; examples from the scan include api/chalicelib/public/content.js, api/chalicelib/public/manifest.json, api/chalicelib/public/segment-snippet.js, chrome_extension/content.js, and 2 more.
 - Review changes touching file, media, JSON, XML, CSV, OCR, or data parsing; examples from the scan include api/app.py, api/chalicelib/classification.py, api/chalicelib/public/content.css, api/chalicelib/public/content.js, and 5 more.
 - Review changes touching database, model, or persistence code; examples from the scan include api/chalicelib/classification.py, api/tests/test_classification.py, docs/plans/2026-06-08-gpt-docs-api-testability-dependency-baseline.md.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,6 +53,11 @@ limits and reducing plaintext exposure in storage diagnostics.
 Unexpected API route failures should return generic 500 errors to callers and
 keep detailed exception text in server logs.
 
+The browser extension runs inside third-party documentation pages. Treat user
+queries, generated answers, and source labels as untrusted text, never markup.
+Parse source URLs before assigning `href`, allow only HTTP(S), and isolate new
+tabs with `noopener noreferrer`.
+
 GitHub Actions uses read-only repository permissions, verifies the pinned
 Checkout does not persist the workflow token into local Git configuration.
 

--- a/VISION.md
+++ b/VISION.md
@@ -39,7 +39,8 @@ Next priorities:
 
 - Improve evaluation of answer quality and citation grounding
 - Modernize OpenAI and Pinecone clients in a dedicated pass
-- Keep Chrome extension behavior aligned with API changes
+- Keep Chrome extension behavior aligned with API changes while preserving
+  text-only extension rendering and HTTP(S)-only source links
 - Document crawler scope and robots.txt/respectful access behavior
 
 Contribution rules:
@@ -68,6 +69,8 @@ Contribution rules:
 - Keep the classification weight schema guard on `/classify/builder` responses.
 - Keep public asset routes path-bound to `api/chalicelib/public`.
 - Keep GitHub Actions aligned with the no-live-credentials local gate.
+- Keep the text-only extension rendering guard in the canonical local and
+  hosted baseline.
 
 ## Security And Accuracy
 

--- a/api/chalicelib/public/content.js
+++ b/api/chalicelib/public/content.js
@@ -12,10 +12,26 @@ function clearInput() {
   document.getElementById("queryInput").value = "";
 }
 
+function setText(element, value) {
+  element.textContent = value == null ? "" : String(value);
+}
+
+function safeHttpUrl(value) {
+  try {
+    var parsed = new URL(String(value));
+    if (parsed.protocol === "https:" || parsed.protocol === "http:") {
+      return parsed.href;
+    }
+  } catch (error) {
+    return null;
+  }
+  return null;
+}
+
 // Create a new <style> element
 var styleElement = document.createElement("style");
 styleElement.type = "text/css";
-styleElement.innerHTML = cssRules;
+styleElement.textContent = cssRules;
 
 // Append the <style> element to the <head> element of the page
 document.head.appendChild(styleElement);
@@ -69,19 +85,19 @@ function addResponse(text, links, parentElement) {
     inputText = inputText + "?";
   }
 
-  h2.innerHTML = inputText;
+  setText(h2, inputText);
 
   response.appendChild(h2);
   // add a p element to the response div element
   var p = document.createElement("p");
   p.className = "response__p";
-  p.innerHTML = text;
+  setText(p, text);
   response.appendChild(p);
 
   // Create another h2 element that says "Sources"
   var h2 = document.createElement("h2");
   h2.className = "modal-response-h2";
-  h2.innerHTML = "Sources";
+  setText(h2, "Sources");
   response.appendChild(h2);
 
   // create a list of a links with the className .modal-response__link
@@ -90,6 +106,10 @@ function addResponse(text, links, parentElement) {
 
   // loop through the links array
   for (var i = 0; i < links.length; i++) {
+    var safeUrl = safeHttpUrl(links[i]);
+    if (!safeUrl) {
+      continue;
+    }
     // create a new list item element
     var newListItem = document.createElement("li");
     // set the className
@@ -99,11 +119,11 @@ function addResponse(text, links, parentElement) {
     // set the className
     newAnchor.className = "modal-response__link";
     // set the href attribute
-    newAnchor.setAttribute("href", links[i]);
+    newAnchor.setAttribute("href", safeUrl);
     // set the target attribute
     newAnchor.setAttribute("target", "_blank");
-    // set the innerHTML
-    newAnchor.innerHTML = links[i];
+    newAnchor.setAttribute("rel", "noopener noreferrer");
+    setText(newAnchor, safeUrl);
 
     // append the anchor element to the list item element
     newListItem.appendChild(newAnchor);
@@ -117,7 +137,7 @@ function addResponse(text, links, parentElement) {
   // add a h3 element to the response div element
   var h3 = document.createElement("h3");
   h3.className = "modal-response__h3";
-  h3.innerHTML = "Was this response useful?";
+  setText(h3, "Was this response useful?");
   response.appendChild(h3);
 
   // create div with class modal-response__button_container
@@ -126,12 +146,12 @@ function addResponse(text, links, parentElement) {
   // create a yes and no button for the user to click with the question was this response useful
   var yesButton = document.createElement("button");
   yesButton.className = "modal-response__button";
-  yesButton.innerHTML = "Yes";
+  setText(yesButton, "Yes");
   buttonContainer.appendChild(yesButton);
 
   var noButton = document.createElement("button");
   noButton.className = "modal-response__button";
-  noButton.innerHTML = "No";
+  setText(noButton, "No");
   buttonContainer.appendChild(noButton);
 
   // add click event listeners to the yes and no buttons
@@ -141,7 +161,7 @@ function addResponse(text, links, parentElement) {
     // create p class for thank you message
     var thankyou = document.createElement("p");
     thankyou.className = "modal-response__p";
-    thankyou.innerHTML = "Thank you for your feedback!";
+    setText(thankyou, "Thank you for your feedback!");
     // append the thank you message to the response div element
     response.appendChild(thankyou);
     // remove the yes and no buttons
@@ -197,7 +217,7 @@ function createLoader(parentElement) {
   // Create an h2 element that says "Gathering sources ..."
   var h2 = document.createElement("h2");
   h2.className = "gpt-loading__h2";
-  h2.innerHTML = "Gathering sources ...";
+  setText(h2, "Gathering sources ...");
 
   // Define the array of messages to rotate
   const messages = [
@@ -210,10 +230,9 @@ function createLoader(parentElement) {
   // Initialize the counter
   let counter = 0;
 
-  // Rotate the innerHTML of the h2 element every 5 seconds
+  // Rotate the loading message every 5 seconds.
   setInterval(function () {
-    // Set the innerHTML to the current message
-    h2.innerHTML = messages[counter];
+    setText(h2, messages[counter]);
 
     // Increment the counter
     counter++;
@@ -253,13 +272,13 @@ function addModal(b) {
     // add a close button to the right of the bar
     var close = document.createElement("span");
     close.className = "close";
-    close.innerHTML = "&times;";
+    setText(close, "×");
     // when the user clicks on the close button, remove the overlay
 
     // Add a title to the top bar
     var title = document.createElement("h2");
     title.className = "top-bar__title";
-    title.innerHTML = "GPT Docs";
+    setText(title, "GPT Docs");
     topBar.appendChild(title);
     // add a pill to the right of the title with experimental with a background of #f22f46 and and a color of a lighter version of that red
     // create a div element to hold the pill
@@ -268,7 +287,7 @@ function addModal(b) {
 
     var pill = document.createElement("span");
     pill.className = "pill";
-    pill.innerHTML = "Experimental";
+    setText(pill, "Experimental");
     // add wave-text class to the pill
     pill.classList.add("wave-text");
 
@@ -381,11 +400,11 @@ function addModal(b) {
     form.appendChild(input);
     var typewriterText = document.createElement("span");
     typewriterText.id = "typewriterText";
-    typewriterText.innerHTML = "";
+    setText(typewriterText, "");
     //form.appendChild(typewriterText);
     var cursor = document.createElement("span");
     cursor.className = "cursor";
-    cursor.innerHTML = "▌";
+    setText(cursor, "▌");
     //form.appendChild(cursor);
 
     // add the form to the right content div element
@@ -464,14 +483,20 @@ document.addEventListener("keydown", function (event) {
 // add an event listener to the new list item
 newListItem.addEventListener("click", addOverlay);
 
-// Set the inner HTML for the new list item (replace with your desired content)
-newListItem.innerHTML =
-  '<a class="docs-nav__link gpt-docs-nav-link">' +
-  '<img src="' +
-  newLogoNavImg +
-  '" alt="Your Alt Text" class="docs-nav__icon">' +
-  '<span class="docs-nav__text"></span>' +
-  "</a>";
+var navLink = document.createElement("a");
+navLink.className = "docs-nav__link gpt-docs-nav-link";
+
+var navIcon = document.createElement("img");
+navIcon.src = newLogoNavImg;
+navIcon.alt = "GPT Docs";
+navIcon.className = "docs-nav__icon";
+
+var navText = document.createElement("span");
+navText.className = "docs-nav__text";
+
+navLink.appendChild(navIcon);
+navLink.appendChild(navText);
+newListItem.appendChild(navLink);
 
 // Get the unordered list element with the class 'docs-nav__secondary'
 var ulElement = document.querySelector(".docs-nav__secondary");

--- a/chrome_extension/content.js
+++ b/chrome_extension/content.js
@@ -12,10 +12,26 @@ function clearInput() {
   document.getElementById("queryInput").value = "";
 }
 
+function setText(element, value) {
+  element.textContent = value == null ? "" : String(value);
+}
+
+function safeHttpUrl(value) {
+  try {
+    var parsed = new URL(String(value));
+    if (parsed.protocol === "https:" || parsed.protocol === "http:") {
+      return parsed.href;
+    }
+  } catch (error) {
+    return null;
+  }
+  return null;
+}
+
 // Create a new <style> element
 var styleElement = document.createElement("style");
 styleElement.type = "text/css";
-styleElement.innerHTML = cssRules;
+styleElement.textContent = cssRules;
 
 // Append the <style> element to the <head> element of the page
 document.head.appendChild(styleElement);
@@ -69,19 +85,19 @@ function addResponse(text, links, parentElement) {
     inputText = inputText + "?";
   }
 
-  h2.innerHTML = inputText;
+  setText(h2, inputText);
 
   response.appendChild(h2);
   // add a p element to the response div element
   var p = document.createElement("p");
   p.className = "response__p";
-  p.innerHTML = text;
+  setText(p, text);
   response.appendChild(p);
 
   // Create another h2 element that says "Sources"
   var h2 = document.createElement("h2");
   h2.className = "modal-response-h2";
-  h2.innerHTML = "Sources";
+  setText(h2, "Sources");
   response.appendChild(h2);
 
   // create a list of a links with the className .modal-response__link
@@ -90,6 +106,10 @@ function addResponse(text, links, parentElement) {
 
   // loop through the links array
   for (var i = 0; i < links.length; i++) {
+    var safeUrl = safeHttpUrl(links[i]);
+    if (!safeUrl) {
+      continue;
+    }
     // create a new list item element
     var newListItem = document.createElement("li");
     // set the className
@@ -99,11 +119,11 @@ function addResponse(text, links, parentElement) {
     // set the className
     newAnchor.className = "modal-response__link";
     // set the href attribute
-    newAnchor.setAttribute("href", links[i]);
+    newAnchor.setAttribute("href", safeUrl);
     // set the target attribute
     newAnchor.setAttribute("target", "_blank");
-    // set the innerHTML
-    newAnchor.innerHTML = links[i];
+    newAnchor.setAttribute("rel", "noopener noreferrer");
+    setText(newAnchor, safeUrl);
 
     // append the anchor element to the list item element
     newListItem.appendChild(newAnchor);
@@ -117,7 +137,7 @@ function addResponse(text, links, parentElement) {
   // add a h3 element to the response div element
   var h3 = document.createElement("h3");
   h3.className = "modal-response__h3";
-  h3.innerHTML = "Was this response useful?";
+  setText(h3, "Was this response useful?");
   response.appendChild(h3);
 
   // create div with class modal-response__button_container
@@ -126,12 +146,12 @@ function addResponse(text, links, parentElement) {
   // create a yes and no button for the user to click with the question was this response useful
   var yesButton = document.createElement("button");
   yesButton.className = "modal-response__button";
-  yesButton.innerHTML = "Yes";
+  setText(yesButton, "Yes");
   buttonContainer.appendChild(yesButton);
 
   var noButton = document.createElement("button");
   noButton.className = "modal-response__button";
-  noButton.innerHTML = "No";
+  setText(noButton, "No");
   buttonContainer.appendChild(noButton);
 
   // add click event listeners to the yes and no buttons
@@ -141,7 +161,7 @@ function addResponse(text, links, parentElement) {
     // create p class for thank you message
     var thankyou = document.createElement("p");
     thankyou.className = "modal-response__p";
-    thankyou.innerHTML = "Thank you for your feedback!";
+    setText(thankyou, "Thank you for your feedback!");
     // append the thank you message to the response div element
     response.appendChild(thankyou);
     // remove the yes and no buttons
@@ -198,7 +218,7 @@ function createLoader(parentElement) {
   // Create an h2 element that says "Gathering sources ..."
   var h2 = document.createElement("h2");
   h2.className = "gpt-loading__h2";
-  h2.innerHTML = "Gathering sources ...";
+  setText(h2, "Gathering sources ...");
 
   // Define the array of messages to rotate
   const messages = [
@@ -211,10 +231,9 @@ function createLoader(parentElement) {
   // Initialize the counter
   let counter = 0;
 
-  // Rotate the innerHTML of the h2 element every 5 seconds
+  // Rotate the loading message every 5 seconds.
   setInterval(function () {
-    // Set the innerHTML to the current message
-    h2.innerHTML = messages[counter];
+    setText(h2, messages[counter]);
 
     // Increment the counter
     counter++;
@@ -254,13 +273,13 @@ function addModal(b) {
     // add a close button to the right of the bar
     var close = document.createElement("span");
     close.className = "close";
-    close.innerHTML = "&times;";
+    setText(close, "×");
     // when the user clicks on the close button, remove the overlay
 
     // Add a title to the top bar
     var title = document.createElement("h2");
     title.className = "top-bar__title";
-    title.innerHTML = "GPT Docs";
+    setText(title, "GPT Docs");
     topBar.appendChild(title);
     // add a pill to the right of the title with experimental with a background of #f22f46 and and a color of a lighter version of that red
     // create a div element to hold the pill
@@ -269,7 +288,7 @@ function addModal(b) {
 
     var pill = document.createElement("span");
     pill.className = "pill";
-    pill.innerHTML = "Experimental";
+    setText(pill, "Experimental");
     // add wave-text class to the pill
     pill.classList.add("wave-text");
 
@@ -382,11 +401,11 @@ function addModal(b) {
     form.appendChild(input);
     var typewriterText = document.createElement("span");
     typewriterText.id = "typewriterText";
-    typewriterText.innerHTML = "";
+    setText(typewriterText, "");
     //form.appendChild(typewriterText);
     var cursor = document.createElement("span");
     cursor.className = "cursor";
-    cursor.innerHTML = "▌";
+    setText(cursor, "▌");
     //form.appendChild(cursor);
 
     // add the form to the right content div element
@@ -465,14 +484,20 @@ document.addEventListener("keydown", function (event) {
 // add an event listener to the new list item
 newListItem.addEventListener("click", addOverlay);
 
-// Set the inner HTML for the new list item (replace with your desired content)
-newListItem.innerHTML =
-  '<a class="docs-nav__link gpt-docs-nav-link">' +
-  '<img src="' +
-  newLogoNavImg +
-  '" alt="Your Alt Text" class="docs-nav__icon">' +
-  '<span class="docs-nav__text"></span>' +
-  "</a>";
+var navLink = document.createElement("a");
+navLink.className = "docs-nav__link gpt-docs-nav-link";
+
+var navIcon = document.createElement("img");
+navIcon.src = newLogoNavImg;
+navIcon.alt = "GPT Docs";
+navIcon.className = "docs-nav__icon";
+
+var navText = document.createElement("span");
+navText.className = "docs-nav__text";
+
+navLink.appendChild(navIcon);
+navLink.appendChild(navText);
+newListItem.appendChild(navLink);
 
 // Get the unordered list element with the class 'docs-nav__secondary'
 var ulElement = document.querySelector(".docs-nav__secondary");

--- a/docs/plans/2026-06-12-safe-extension-rendering.md
+++ b/docs/plans/2026-06-12-safe-extension-rendering.md
@@ -1,0 +1,98 @@
+---
+title: Safe Extension Rendering
+type: fix
+status: completed
+date: 2026-06-12
+origin: issue 16 and pull request 17
+execution: code
+---
+
+# Safe Extension Rendering
+
+## Context
+
+Both shipped copies of the GPT Docs content script assign user queries, model
+responses, and source links through `innerHTML`. The script runs inside Twilio
+documentation pages, so remote or user-controlled strings can be interpreted
+as host-page markup instead of displayed as text. Source links are also opened
+with `_blank` without opener isolation or protocol validation.
+
+Pull request 17 proposed the core text-rendering fix, but it predates the
+current API baseline and does not connect its regression guard to `make check`.
+The two bundles now also intentionally differ in their icon asset and API
+endpoint, which this change must preserve.
+
+## Priority
+
+Issue 16 is labeled P1 and URGENT because the vulnerable sinks cross a browser
+extension trust boundary and can modify a third-party documentation page.
+
+## Prioritized Engineering Backlog
+
+1. Remove scriptable HTML sinks from both content-script bundles now.
+2. Add browser-level extension integration tests when the project gains a
+   maintained extension test harness.
+3. Consolidate the duplicated content script through a build step only if the
+   repository adopts a JavaScript toolchain.
+
+## Requirements
+
+- R1. User query text, model response text, loader text, labels, and static UI
+  text must be assigned through text-only DOM APIs.
+- R2. Source links must be parsed and restricted to `http:` or `https:` before
+  an `href` is assigned.
+- R3. External source links opened with `_blank` must use
+  `rel="noopener noreferrer"`.
+- R4. The navigation item must be built with DOM APIs rather than an HTML
+  string.
+- R5. Both `chrome_extension/content.js` and
+  `api/chalicelib/public/content.js` must receive the same security behavior
+  while retaining their existing icon and endpoint differences.
+- R6. The canonical `make check` gate must run syntax and static security
+  regressions for both content-script copies.
+- R7. Existing API behavior and the dependency-free Python test suite must
+  remain unchanged.
+
+## Implementation Units
+
+### U1. Replace HTML rendering sinks
+
+- **Files:** `chrome_extension/content.js`,
+  `api/chalicelib/public/content.js`
+- Add shared text and URL helpers within each bundle, replace `innerHTML`
+  assignments, validate source URLs, isolate external links, and construct the
+  nav item through element APIs.
+
+### U2. Enforce the browser security contract
+
+- **Files:** `scripts/check-extension-rendering.sh`,
+  `scripts/check-baseline.sh`
+- Reject HTML sinks and missing URL/opener protections, syntax-check both
+  bundles with Node, and run the guard from the canonical baseline.
+
+### U3. Record the public behavior
+
+- **Files:** `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`
+- Document text-only remote rendering, HTTP(S)-only source links, and the
+  extension verification gate.
+
+## Scope Boundaries
+
+- Do not change API endpoints, icon assets, analytics, authentication, or
+  response schemas.
+- Do not add a JavaScript package manager or runtime dependency.
+- Do not intentionally preserve HTML formatting returned by the model.
+
+## Verification
+
+- `scripts/check-extension-rendering.sh`
+- `node --check chrome_extension/content.js`
+- `node --check api/chalicelib/public/content.js`
+- `make verify`
+- `git diff --check`
+- Mutations restoring response `innerHTML`, unsafe URL assignment, or missing
+  opener isolation must fail the regression guard.
+
+Completed on 2026-06-12 with both content-script copies syntax-checked, the
+text and URL helper behavior exercised, all 41 API tests passing, the canonical
+baseline green, and hostile rendering mutations rejected.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -33,6 +33,8 @@ CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 CI_PLAN="$ROOT_DIR/docs/plans/2026-06-10-ci-baseline.md"
 CACHE_EXPIRATION_PLAN="$ROOT_DIR/docs/plans/2026-06-10-cache-expiration-boundary.md"
 CACHE_KEY_PLAN="$ROOT_DIR/docs/plans/2026-06-12-cache-query-key-hashing.md"
+EXTENSION_RENDERING_PLAN="$ROOT_DIR/docs/plans/2026-06-12-safe-extension-rendering.md"
+EXTENSION_RENDERING_CHECK="$ROOT_DIR/scripts/check-extension-rendering.sh"
 
 require_file() {
   path=$1
@@ -75,6 +77,8 @@ for path in \
   "docs/plans/2026-06-10-ci-baseline.md" \
   "docs/plans/2026-06-10-cache-expiration-boundary.md" \
   "docs/plans/2026-06-12-cache-query-key-hashing.md" \
+  "docs/plans/2026-06-12-safe-extension-rendering.md" \
+  "scripts/check-extension-rendering.sh" \
   "scripts/check-baseline.sh"; do
   require_file "$path"
 done
@@ -317,6 +321,7 @@ if ! grep -Fq "Run \`make verify\`" "$VISION" ||
   ! grep -Fq "retrieval context length" "$VISION" ||
   ! grep -Fq "cache expiration" "$VISION" ||
   ! grep -Fq "fixed-size SHA-256 cache keys" "$VISION" ||
+  ! grep -Fq "text-only extension rendering" "$VISION" ||
   ! grep -Fq "generic 500 errors" "$VISION" ||
   ! grep -Fq "classification weight schema" "$VISION"; then
   printf '%s\n' "VISION.md must keep the make verify and API auth contribution rules visible." >&2
@@ -337,6 +342,7 @@ if ! grep -Fq "source baseline guard" "$CHANGES" ||
   ! grep -Fq "retrieval context length" "$CHANGES" ||
   ! grep -Fq "cache entries" "$CHANGES" ||
   ! grep -Fq "SHA-256 identities" "$CHANGES" ||
+  ! grep -Fq "text-only DOM rendering" "$CHANGES" ||
   ! grep -Fq "generic 500 errors" "$CHANGES" ||
   ! grep -Fq "classification weight schema" "$CHANGES"; then
   printf '%s\n' "CHANGES.md must record the source baseline and auth guards." >&2
@@ -357,6 +363,7 @@ if ! grep -Fq "status: completed" "$PLAN" ||
   ! grep -Fq "status: completed" "$CI_PLAN" ||
   ! grep -Fq "status: completed" "$CACHE_EXPIRATION_PLAN" ||
   ! grep -Fq "status: completed" "$CACHE_KEY_PLAN" ||
+  ! grep -Fq "status: completed" "$EXTENSION_RENDERING_PLAN" ||
   ! grep -Fq "status: completed" "$ROOT_DIR/docs/plans/2026-06-09-twilio-link-host-filtering.md"; then
   printf '%s\n' "Plan documents must be marked completed." >&2
   exit 1
@@ -379,5 +386,6 @@ if ! grep -Fq "GitHub Actions" "$CI_PLAN" ||
 fi
 PYTHONPATH="$ROOT_DIR/api" python -m unittest discover -s "$ROOT_DIR/api/tests"
 python -m compileall -q "$ROOT_DIR/api/app.py" "$ROOT_DIR/api/chalicelib" "$ROOT_DIR/api/tests"
+"$EXTENSION_RENDERING_CHECK"
 
 printf '%s\n' "GPT Docs API baseline checks passed."

--- a/scripts/check-extension-rendering.sh
+++ b/scripts/check-extension-rendering.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+FILES="
+$ROOT_DIR/chrome_extension/content.js
+$ROOT_DIR/api/chalicelib/public/content.js
+"
+
+for file in $FILES; do
+  if grep -Fq 'innerHTML' "$file"; then
+    printf '%s\n' "$file must not render content with innerHTML." >&2
+    exit 1
+  fi
+
+  for contract in \
+    'function setText(element, value)' \
+    'function safeHttpUrl(value)' \
+    'parsed.protocol === "https:" || parsed.protocol === "http:"' \
+    'newAnchor.setAttribute("href", safeUrl)' \
+    'newAnchor.setAttribute("rel", "noopener noreferrer")' \
+    'setText(h2, inputText)' \
+    'setText(p, text)' \
+    'newListItem.appendChild(navLink)'; do
+    if ! grep -Fq "$contract" "$file"; then
+      printf '%s\n' "$file is missing extension rendering contract: $contract" >&2
+      exit 1
+    fi
+  done
+
+  node --check "$file"
+  node - "$file" <<'EOF'
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const vm = require("node:vm");
+
+const file = process.argv[2];
+const source = fs.readFileSync(file, "utf8");
+const marker = "// Create a new <style> element";
+const markerIndex = source.indexOf(marker);
+assert.notEqual(markerIndex, -1, `${file} is missing the helper boundary`);
+
+const context = { URL };
+vm.createContext(context);
+vm.runInContext(source.slice(0, markerIndex), context, { filename: file });
+
+const element = {};
+context.setText(element, '<img src=x onerror="alert(1)">');
+assert.equal(element.textContent, '<img src=x onerror="alert(1)">');
+assert.equal(context.safeHttpUrl("javascript:alert(1)"), null);
+assert.equal(context.safeHttpUrl("data:text/html,unsafe"), null);
+assert.equal(context.safeHttpUrl("https://www.twilio.com/docs"), "https://www.twilio.com/docs");
+assert.equal(context.safeHttpUrl("http://example.test/path"), "http://example.test/path");
+EOF
+done
+
+printf '%s\n' "GPT Docs extension rendering checks passed."


### PR DESCRIPTION
## Summary

Historical closed pull request: [URGENT] Render extension responses safely

### Original Description

### Summary
- render user queries, model responses, labels, and loader content through text-only DOM APIs in both extension bundles
- accept only parsed HTTP(S) source URLs and isolate links opened in a new tab
- build the navigation item without HTML strings and preserve the bundles' existing endpoint/icon differences
- enforce JavaScript syntax and rendering security contracts in the canonical `make check` baseline

## Verification
- 41 API tests passed
- `make verify`
- `node --check chrome_extension/content.js`
- `node --check api/chalicelib/public/content.js`
- behavioral text and URL helper checks for both bundles
- hostile mutations restoring response `innerHTML`, direct unsafe `href`, and missing opener isolation were each rejected
- `git diff --check`

Closes #16.
Supersedes #17 with a current-`main` implementation wired into the canonical hosted gate.

## Baseline

The original pull request predates the fleet-standard description contract; repository history and code remain unchanged by this metadata update.

## Improvements

The implementation intent remains the SwiftUI networking, safety, testing, CI, or documentation change described by the title and preserved original description.

## Validation

No code was rerun solely for this metadata normalization. Fresh exact-master local and hosted validation is recorded separately in the engineering-bar tracker.

## Risk

This description-only normalization changes no source, commit, branch, credential, project setting, dependency, or runtime behavior.

## Follow-Ups

No follow-up is required for this metadata-only update; Apple-platform and live-provider limitations remain tracked in the exact-head evidence.
