### PR TITLE
fix: disable stale Vercel deployments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-12
 
+- Explicitly disabled unintended Vercel Git deployments so the repository's
+  deployment status reflects its Chalice API and GitHub Pages workflows.
 - Replaced extension `innerHTML` sinks with text-only DOM rendering, restricted
   source links to HTTP(S), isolated new tabs, and added canonical regressions.
 - Replaced raw DynamoDB query partition keys with namespaced SHA-256 identities

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ that remote content uses text-only rendering with HTTP(S)-only source links.
 GitHub Actions installs the pinned API requirements on Python 3.10, verifies
 dependency consistency, checks out without persisting the workflow token, and
 runs the same offline `make check` baseline.
+The API implementation targets AWS Chalice, while repository settings publish
+the static project content through GitHub Pages. Vercel automatic Git deployments are disabled
+in `vercel.json` because their rewrite targeted the Flask entry point retired
+during the 2023 Chalice migration.
 Request validation rejects missing, non-string, whitespace-only, and over the
 maximum query length values before model or retrieval work starts.
 The retrieval context length guard caps each accepted Pinecone metadata text

--- a/VISION.md
+++ b/VISION.md
@@ -69,6 +69,8 @@ Contribution rules:
 - Keep the classification weight schema guard on `/classify/builder` responses.
 - Keep public asset routes path-bound to `api/chalicelib/public`.
 - Keep GitHub Actions aligned with the no-live-credentials local gate.
+- Keep Vercel automatic Git deployments disabled; the maintained surfaces are
+  the Chalice API implementation and the repository's GitHub Pages deployment.
 - Keep the text-only extension rendering guard in the canonical local and
   hosted baseline.
 

--- a/docs/plans/2026-06-12-vercel-deployment-ownership.md
+++ b/docs/plans/2026-06-12-vercel-deployment-ownership.md
@@ -1,0 +1,55 @@
+---
+title: Vercel Deployment Ownership
+type: fix
+status: completed
+date: 2026-06-12
+origin: repository-wide pull request audit
+execution: code
+---
+
+# Vercel Deployment Ownership
+
+## Context
+
+The repository began as a Vercel Flask sample with `api/index.py` and a rewrite
+that sent every request to `/api/index`. Commit `2ad24a9` deleted that function
+when the API moved to AWS Chalice in April 2023, but the original rewrite and
+connected Vercel project remained. Vercel therefore reported failed production
+deployments on otherwise green commits while GitHub Pages continued to publish
+the static repository content successfully.
+
+The Chalice entry point uses the AWS Lambda event/context interface, its pinned
+dependencies live under `api/`, and the repository includes historical binary
+vendor artifacts. Treating that tree as an inferred Vercel Python function
+would create a second, undocumented deployment architecture rather than repair
+the maintained one.
+
+## Requirements
+
+- R1. Automatic Vercel Git deployments must be disabled for every branch.
+- R2. The configuration must use the current `git.deploymentEnabled` setting.
+- R3. The retired `/api/index` rewrite must not remain in configuration.
+- R4. The canonical baseline must parse the configuration and reject missing,
+  malformed, selectively enabled, or globally enabled deployment settings.
+- R5. Documentation must identify the Chalice API target and GitHub Pages as
+  the maintained deployment surfaces.
+- R6. Existing API, extension, test, and GitHub Actions behavior must remain
+  unchanged.
+
+## Implementation
+
+- Added root `vercel.json` with `git.deploymentEnabled` set to `false`.
+- Added a structured JSON contract to `scripts/check-baseline.sh`.
+- Documented deployment ownership in the README, vision, and changelog.
+
+## Verification
+
+- `make verify`
+- `git diff --check`
+- A mutation that sets `git.deploymentEnabled` to `true` must fail.
+- A mutation that replaces the global boolean with a branch map must fail.
+- A mutation that restores the `/api/index` rewrite must fail.
+- A mutation that removes `vercel.json` must fail.
+
+Completed on 2026-06-12 after the full offline API and extension baseline passed
+and hostile Vercel configuration mutations were rejected.

--- a/docs/plans/2026-06-12-vercel-deployment-ownership.md
+++ b/docs/plans/2026-06-12-vercel-deployment-ownership.md
@@ -53,3 +53,24 @@ the maintained one.
 
 Completed on 2026-06-12 after the full offline API and extension baseline passed
 and hostile Vercel configuration mutations were rejected.
+
+## Work Completed
+
+- Disabled automatic Vercel Git deployments globally with the current
+  `git.deploymentEnabled` setting and removed the retired `/api/index` rewrite.
+- Preserved AWS Chalice as the maintained API target and GitHub Pages as the
+  maintained static publishing surface.
+- Added structured configuration validation and deployment-ownership
+  documentation without changing API, extension, test, or Actions behavior.
+
+## Verification Completed
+
+- `make verify`, all 41 API tests, Python compilation, the API baseline,
+  extension-rendering checks, and `git diff --check` passed locally on Python
+  3.12.
+- Implementation push run `27395011365` and pull-request run `27395017871`
+  passed at commit `e8787d8914229c5524d267820284cfe3a753ae67`.
+- Mutations enabling deployments globally, using a branch map, restoring the
+  retired rewrite, or removing `vercel.json` were rejected by the baseline.
+- This evidence validates the repository configuration; no claim is made that
+  an external Vercel project setting was inspected through the Vercel API.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -35,6 +35,8 @@ CACHE_EXPIRATION_PLAN="$ROOT_DIR/docs/plans/2026-06-10-cache-expiration-boundary
 CACHE_KEY_PLAN="$ROOT_DIR/docs/plans/2026-06-12-cache-query-key-hashing.md"
 EXTENSION_RENDERING_PLAN="$ROOT_DIR/docs/plans/2026-06-12-safe-extension-rendering.md"
 EXTENSION_RENDERING_CHECK="$ROOT_DIR/scripts/check-extension-rendering.sh"
+VERCEL_CONFIG="$ROOT_DIR/vercel.json"
+VERCEL_PLAN="$ROOT_DIR/docs/plans/2026-06-12-vercel-deployment-ownership.md"
 
 require_file() {
   path=$1
@@ -51,6 +53,7 @@ for path in \
   "SECURITY.md" \
   "VISION.md" \
   "Makefile" \
+  "vercel.json" \
   "api/requirements.txt" \
   "api/app.py" \
   "api/chalicelib/auth.py" \
@@ -78,10 +81,27 @@ for path in \
   "docs/plans/2026-06-10-cache-expiration-boundary.md" \
   "docs/plans/2026-06-12-cache-query-key-hashing.md" \
   "docs/plans/2026-06-12-safe-extension-rendering.md" \
+  "docs/plans/2026-06-12-vercel-deployment-ownership.md" \
   "scripts/check-extension-rendering.sh" \
   "scripts/check-baseline.sh"; do
   require_file "$path"
 done
+
+python - "$VERCEL_CONFIG" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+config = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if config.get("git", {}).get("deploymentEnabled") is not False:
+    raise SystemExit(
+        "vercel.json must disable automatic Git deployments for every branch"
+    )
+if "rewrites" in config:
+    raise SystemExit(
+        "vercel.json must not route requests to the retired api/index function"
+    )
+PY
 
 for target in "lint:" "test:" "build: compile" "compile:" "check:" "verify: test compile check"; do
   if ! grep -Fq "$target" "$MAKEFILE"; then
@@ -302,6 +322,7 @@ if ! grep -Fq "make verify" "$README" ||
   ! grep -Fq "fixed-size SHA-256 identity" "$README" ||
   ! grep -Fq "generic 500 errors" "$README" ||
   ! grep -Fq "classification weight schema" "$README" ||
+  ! grep -Fq "Vercel automatic Git deployments are disabled" "$README" ||
   ! grep -Fq "OpenAI" "$README" ||
   ! grep -Fq "Pinecone" "$README"; then
   printf '%s\n' "README must document verification, changelog, and external service boundaries." >&2
@@ -328,6 +349,11 @@ if ! grep -Fq "Run \`make verify\`" "$VISION" ||
   exit 1
 fi
 
+if ! grep -Fq "Vercel automatic Git deployments" "$VISION"; then
+  printf '%s\n' "VISION.md must keep deployment ownership explicit." >&2
+  exit 1
+fi
+
 if ! grep -Fq "source baseline guard" "$CHANGES" ||
   ! grep -Fq "GitHub Actions" "$CHANGES" ||
   ! grep -Fq "make lint" "$CHANGES" ||
@@ -349,6 +375,11 @@ if ! grep -Fq "source baseline guard" "$CHANGES" ||
   exit 1
 fi
 
+if ! grep -Fq "disabled unintended Vercel Git deployments" "$CHANGES"; then
+  printf '%s\n' "CHANGES.md must record the Vercel deployment boundary." >&2
+  exit 1
+fi
+
 if ! grep -Fq "status: completed" "$PLAN" ||
   ! grep -Fq "status: completed" "$CHECK_PLAN" ||
   ! grep -Fq "status: completed" "$AUTH_PLAN" ||
@@ -364,6 +395,7 @@ if ! grep -Fq "status: completed" "$PLAN" ||
   ! grep -Fq "status: completed" "$CACHE_EXPIRATION_PLAN" ||
   ! grep -Fq "status: completed" "$CACHE_KEY_PLAN" ||
   ! grep -Fq "status: completed" "$EXTENSION_RENDERING_PLAN" ||
+  ! grep -Fq "status: completed" "$VERCEL_PLAN" ||
   ! grep -Fq "status: completed" "$ROOT_DIR/docs/plans/2026-06-09-twilio-link-host-filtering.md"; then
   printf '%s\n' "Plan documents must be marked completed." >&2
   exit 1

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -401,6 +401,35 @@ if ! grep -Fq "status: completed" "$PLAN" ||
   exit 1
 fi
 
+python - "$VERCEL_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text(encoding="utf-8")
+frontmatter_parts = plan.split("---", 2)
+frontmatter = frontmatter_parts[1] if len(frontmatter_parts) == 3 else ""
+statuses = re.findall(r"^status: .+$", frontmatter, flags=re.MULTILINE)
+sections = plan.split("## Verification Completed\n", 1)
+verification = sections[1] if len(sections) == 2 else ""
+required = (
+    "`make verify`, all 41 API tests",
+    "push run `27395011365`",
+    "pull-request run `27395017871`",
+    "Mutations enabling deployments globally",
+    "no claim is made that",
+)
+
+if (
+    statuses != ["status: completed"]
+    or any(item not in verification for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Vercel deployment-ownership plan must remain completed with actual verification recorded."
+    )
+PY
+
 if ! grep -Fq "Mutations restoring raw query strings" "$CACHE_KEY_PLAN"; then
   printf '%s\n' "Cache query-key plan must record completed mutation verification." >&2
   exit 1

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
-  "rewrites": [
-    { "source": "/(.*)", "destination": "/api/index" }
-  ]
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": false
+  }
 }


### PR DESCRIPTION
## Summary

Vercel no longer attempts a production deployment that is guaranteed to fail against the retired `/api/index` Flask entry point. The maintained Chalice API implementation and GitHub Pages deployment remain unchanged.

## Baseline

The original Vercel rewrite survived the 2023 migration from Flask to Chalice. This change replaces it with the current global Git deployment opt-out and adds a structured baseline contract so automatic or selectively enabled Vercel deployments cannot return unnoticed.

## Improvements

- Replaces the stale `/api/index` Vercel rewrite with the current global Git deployment opt-out.
- Adds structured contracts that reject globally enabled, selectively enabled, malformed, missing, or retired-rewrite Vercel configurations.
- Leaves the maintained Chalice API implementation and GitHub Pages deployment path unchanged.

## Validation

- `make verify` (41 API tests, compilation, baseline contracts, and extension rendering checks)
- `git diff --check`
- Completed-plan evidence contract rejects stale status, placeholder evidence, and falsified run IDs
- Exact-head push run `27410063540`, pull-request run `27410065043`, and CodeQL run `27410063333` passed at `ac366f7df1843158a897c578de130a66b8d592f6`
- Hostile mutations rejected globally enabled deployments, branch-specific configuration, the retired rewrite, malformed JSON, and a missing config file
- Changed-line secret scan found no credentials or private keys

## Risk

- Vercel project-level settings are external to the repository and may still require authenticated cleanup or disconnection.
- The opt-out must remain present and valid to prevent the stale Vercel integration from resuming automatic deployments.
- GitHub Pages and the Chalice API are intentionally unchanged, so their runtime behavior is covered only by the existing checks and post-merge observation window.

## Follow-Ups

- Disconnect or correct the stale Vercel project through authenticated project settings if any deployment status returns.
- Confirm the first `main` run keeps GitHub Actions and GitHub Pages successful without a new Vercel production deployment.
- Keep the structured Vercel configuration contract synchronized with any deliberate future deployment-platform change.

## Post-Deploy Monitoring & Validation

- Watch this PR and its merge commit for GitHub Actions `check`; expected signal is success.
- Confirm Vercel does not attach a new failing Production deployment status after the configuration is present on the branch and on `main`.
- Confirm the repository's GitHub Pages deployment remains successful after merge.
- Failure trigger: a new Vercel failure status, a missing GitHub Pages deployment, or a failed `check` run. Mitigation is to revert this commit and disconnect or correct the stale Vercel project through its authenticated project settings.
- Validation window: PR checks and the first post-merge `main` run; owner: repository maintainer.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)