### PR TITLE
Validate cached response data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-13
+
+- Enforced one separator-aware 4,000-character total retrieval context budget
+  across all Pinecone matches before OpenAI prompt assembly.
+
 ## 2026-06-12
 
 - Pinned the hosted pip bootstrap to 26.1.2 and added contracts rejecting

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Validated cached response payloads and reapplied HTTPS Twilio citation
+  filtering to cache hits so legacy data cannot bypass current link policy.
 - Enforced one separator-aware 4,000-character total retrieval context budget
   across all Pinecone matches before OpenAI prompt assembly.
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - Cache reads and writes use a fixed-size SHA-256 identity in the existing
   `query_string` key attribute, avoiding raw user questions and DynamoDB key
   length failures for accepted long or Unicode queries.
+- Cache hits require string responses and string-list links, and cached links
+  are rechecked against the current HTTPS Twilio-host citation policy.
 - Keep the classification weight schema limited to numeric `with_code`,
   `minimal_code`, and `no_code` values.
 - Twilio link host filtering keeps generated answer links limited to HTTPS

--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ in `vercel.json` because their rewrite targeted the Flask entry point retired
 during the 2023 Chalice migration.
 Request validation rejects missing, non-string, whitespace-only, and over the
 maximum query length values before model or retrieval work starts.
-The retrieval context length guard caps each accepted Pinecone metadata text
-chunk before generated-answer prompt assembly.
+The retrieval context length guard enforces one separator-aware 4,000-character
+total retrieval context budget across accepted Pinecone matches before
+generated-answer prompt assembly. Links are returned only for included context.
 Classification responses are constrained to the expected classification weight
 schema before `/classify/builder` returns model-produced JSON to callers.
 
@@ -121,6 +122,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   metadata is skipped before answer generation.
 - Keep the retrieval context length guard in place so oversized Pinecone
   metadata cannot expand generated-answer prompts without bound.
+- Keep the total retrieval context budget shared across all matches, including
+  separators, rather than applying the limit independently per match.
 - Keep unexpected route failures logged server-side while callers receive
   generic 500 errors.
 - Keep user queries and model responses on text-only DOM rendering in both

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,8 +42,10 @@ For web services, APIs, sockets, or scraping workflows, prioritize reports invol
 
 For AI-generated responses, validate model output schemas before exposing values to callers. The `/classify/builder` response must remain limited to finite numeric `with_code`, `minimal_code`, and `no_code` weights.
 
-Retrieved document context should stay bounded before it is assembled into
-generated-answer prompts.
+Retrieved document context should share one separator-aware total length budget
+across all provider matches before it is assembled into generated-answer
+prompts. Links for excluded context should not be returned as supporting
+sources.
 Generated-answer cache entries should carry a bounded `expires_at` lifetime;
 enable DynamoDB TTL on that attribute so stale query data is physically removed.
 Cache partition keys use a namespaced SHA-256 digest rather than raw user

--- a/VISION.md
+++ b/VISION.md
@@ -30,6 +30,7 @@ Priority:
 - Preserve one-day cache expiration and the DynamoDB `expires_at` TTL attribute
 - Preserve fixed-size SHA-256 cache keys so raw user queries are not DynamoDB
   partition-key material
+- Treat malformed cache payloads as misses and revalidate cached citations
 - Keep unexpected route failures behind generic 500 errors
 - Keep request validation bounded by a maximum query length before model work
 - Keep the classification weight schema explicit and numeric before returning

--- a/VISION.md
+++ b/VISION.md
@@ -26,6 +26,7 @@ Priority:
 - Preserve Twilio link host filtering for generated answer citations
 - Preserve the retrieval metadata guard before answer generation
 - Preserve the retrieval context length guard before prompt assembly
+- Preserve one total retrieval context budget across all matches and separators
 - Preserve one-day cache expiration and the DynamoDB `expires_at` TTL attribute
 - Preserve fixed-size SHA-256 cache keys so raw user queries are not DynamoDB
   partition-key material
@@ -66,6 +67,8 @@ Contribution rules:
   generation.
 - Keep the retrieval context length guard on accepted Pinecone metadata before
   prompt assembly.
+- Keep the total retrieval context budget shared across matches and omit source
+  links for context excluded from the prompt.
 - Keep cache expiration enforced before returning generated-answer entries.
 - Keep cache reads and writes on the same namespaced query digest while
   retaining the existing DynamoDB table and `query_string` attribute.

--- a/api/app.py
+++ b/api/app.py
@@ -97,6 +97,15 @@ def is_twilio_doc_url(url):
     )
 
 
+def filter_twilio_doc_urls(urls):
+    """Return unique HTTPS Twilio documentation links in deterministic order."""
+    filtered_urls = []
+    for url in urls:
+        if is_twilio_doc_url(url) and url not in filtered_urls:
+            filtered_urls.append(url)
+    return sorted(filtered_urls)
+
+
 def metadata_text_and_url(item):
     """Return usable retrieval context and URL metadata from a Pinecone match."""
     metadata = item.get('metadata') if isinstance(item, dict) else getattr(
@@ -238,11 +247,7 @@ def make_query(query: str) -> Tuple[str, List[str]]:
     response = generate_response(augmented_query)
 
     # Keep this explicit loop compatible with Chalice's IAM policy analyzer.
-    filtered_urls = []
-    for url in urls:
-        if is_twilio_doc_url(url) and url not in filtered_urls:
-            filtered_urls.append(url)
-    urls = sorted(filtered_urls)
+    urls = filter_twilio_doc_urls(urls)
 
     return response, urls
 
@@ -286,7 +291,8 @@ def ask_question():
         cache_entry = get_cached_response(query)
         if cache_entry:
             return Response(body={'response': cache_entry['response'],
-                                  'links': cache_entry['links']},
+                                  'links': filter_twilio_doc_urls(
+                                      cache_entry['links'])},
                             status_code=200)
 
         # Get the response and links using the make_query function

--- a/api/app.py
+++ b/api/app.py
@@ -60,6 +60,7 @@ PUBLIC_CONTENT_TYPES = {
     '.svg': 'image/svg+xml',
 }
 MAX_RETRIEVAL_CONTEXT_LENGTH = 4000
+RETRIEVAL_CONTEXT_SEPARATOR = "\n\n---\n\n"
 
 
 def safe_public_file_path(filename):
@@ -207,6 +208,7 @@ def make_query(query: str) -> Tuple[str, List[str]]:
     # Initialize lists to store contexts and URLs
     contexts = []
     urls = []
+    remaining_context_length = MAX_RETRIEVAL_CONTEXT_LENGTH
 
     # Extract the contexts and URLs from the query results
     matches = res.get('matches', []) if hasattr(res, 'get') else getattr(
@@ -216,10 +218,21 @@ def make_query(query: str) -> Tuple[str, List[str]]:
         context, url = metadata_text_and_url(item)
         if context is None:
             continue
-        contexts.append(context)
-        urls.append(url)
 
-    augmented_query = "\n\n---\n\n".join(contexts)+"\n\n-----\n\n"+query
+        separator_length = len(RETRIEVAL_CONTEXT_SEPARATOR) if contexts else 0
+        available_length = remaining_context_length - separator_length
+        if available_length <= 0:
+            break
+
+        bounded_context = context[:available_length]
+        contexts.append(bounded_context)
+        urls.append(url)
+        remaining_context_length -= separator_length + len(bounded_context)
+
+        if remaining_context_length == 0:
+            break
+
+    augmented_query = RETRIEVAL_CONTEXT_SEPARATOR.join(contexts)+"\n\n-----\n\n"+query
 
     # Generate response
     response = generate_response(augmented_query)

--- a/api/chalicelib/cache.py
+++ b/api/chalicelib/cache.py
@@ -43,6 +43,12 @@ def get_cached_response(query, table=None, now=None):
     if expires_at <= current_time:
         return None
 
+    response = cache_entry.get('response')
+    links = cache_entry.get('links')
+    if (not isinstance(response, str) or not isinstance(links, list) or
+            any(not isinstance(link, str) for link in links)):
+        return None
+
     return cache_entry
 
 

--- a/api/tests/test_app_auth.py
+++ b/api/tests/test_app_auth.py
@@ -129,6 +129,51 @@ class AppAuthTests(unittest.TestCase):
         make_query.assert_called_once_with("How?")
         cache.assert_called_once_with("How?", "answer", ["https://twilio.com/docs"])
 
+    def test_ask_reapplies_twilio_link_policy_to_cached_response(self):
+        request = FakeRequest(
+            headers={GPT_DOCS_API_KEY_HEADER: "server-key"},
+            json_body={"query": "How?"},
+        )
+        self.app_module.app.current_request = request
+        cached_response = {
+            "response": "cached answer",
+            "links": [
+                "https://www.twilio.com/docs/b",
+                "https://example.com/?next=twilio.com",
+                "http://www.twilio.com/docs/a",
+                "https://docs.twilio.com/reference",
+                "https://www.twilio.com/docs/b",
+            ],
+        }
+
+        with patch.dict(os.environ, {GPT_DOCS_API_KEY_ENV: "server-key"}):
+            with patch.object(
+                self.app_module,
+                "get_cached_response",
+                return_value=cached_response,
+            ):
+                with patch.object(
+                    self.app_module,
+                    "make_query",
+                    side_effect=AssertionError("should not run"),
+                ) as make_query:
+                    with patch.object(self.app_module, "store_in_cache") as cache:
+                        response = self.app_module.ask_question()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.body,
+            {
+                "response": "cached answer",
+                "links": [
+                    "https://docs.twilio.com/reference",
+                    "https://www.twilio.com/docs/b",
+                ],
+            },
+        )
+        make_query.assert_not_called()
+        cache.assert_not_called()
+
     def test_ask_returns_generic_error_for_unexpected_failures(self):
         request = FakeRequest(
             headers={GPT_DOCS_API_KEY_HEADER: "server-key"},

--- a/api/tests/test_app_auth.py
+++ b/api/tests/test_app_auth.py
@@ -344,6 +344,70 @@ class AppAuthTests(unittest.TestCase):
             "x" * self.app_module.MAX_RETRIEVAL_CONTEXT_LENGTH + "\n\n-----\n\nHow?",
         )
 
+    def test_make_query_bounds_total_context_and_excludes_unused_links(self):
+        first_context = "a" * 1000
+        second_context = "b" * self.app_module.MAX_RETRIEVAL_CONTEXT_LENGTH
+
+        class FakeIndex:
+            def query(self, *args, **kwargs):
+                return {
+                    "matches": [
+                        {
+                            "metadata": {
+                                "text": first_context,
+                                "url": "https://www.twilio.com/docs/first",
+                            }
+                        },
+                        {
+                            "metadata": {
+                                "text": second_context,
+                                "url": "https://www.twilio.com/docs/second",
+                            }
+                        },
+                        {
+                            "metadata": {
+                                "text": "excluded context",
+                                "url": "https://www.twilio.com/docs/excluded",
+                            }
+                        },
+                    ]
+                }
+
+        with patch.object(self.app_module, "get_embeddings", return_value=[0.1]):
+            with patch.object(self.app_module, "get_index", return_value=FakeIndex()):
+                with patch.object(
+                    self.app_module,
+                    "generate_response",
+                    return_value="answer",
+                ) as generate_response:
+                    response, links = self.app_module.make_query("How?")
+
+        self.assertEqual(response, "answer")
+        self.assertEqual(
+            links,
+            [
+                "https://www.twilio.com/docs/first",
+                "https://www.twilio.com/docs/second",
+            ],
+        )
+        augmented_query = generate_response.call_args[0][0]
+        context_text, query = augmented_query.split("\n\n-----\n\n", 1)
+        self.assertEqual(query, "How?")
+        self.assertEqual(
+            len(context_text),
+            self.app_module.MAX_RETRIEVAL_CONTEXT_LENGTH,
+        )
+        self.assertEqual(
+            context_text,
+            first_context
+            + self.app_module.RETRIEVAL_CONTEXT_SEPARATOR
+            + "b" * (
+                self.app_module.MAX_RETRIEVAL_CONTEXT_LENGTH
+                - len(first_context)
+                - len(self.app_module.RETRIEVAL_CONTEXT_SEPARATOR)
+            ),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/api/tests/test_cache.py
+++ b/api/tests/test_cache.py
@@ -91,6 +91,23 @@ class CacheTests(unittest.TestCase):
         self.assertIsNone(get_cached_response("expired", table=expired, now=100))
         self.assertIsNone(get_cached_response("legacy", table=missing_expiry, now=100))
 
+    def test_get_cached_response_rejects_malformed_payload_shape(self):
+        from chalicelib.cache import get_cached_response
+
+        malformed_items = [
+            {"links": ["url"], "expires_at": 200},
+            {"response": 123, "links": ["url"], "expires_at": 200},
+            {"response": "answer", "expires_at": 200},
+            {"response": "answer", "links": "url", "expires_at": 200},
+            {"response": "answer", "links": [123], "expires_at": 200},
+        ]
+
+        for item in malformed_items:
+            with self.subTest(item=item):
+                self.assertIsNone(
+                    get_cached_response("legacy", table=FakeTable(item), now=100)
+                )
+
     def test_store_in_cache_writes_existing_item_shape(self):
         from chalicelib.cache import cache_key, store_in_cache
 

--- a/docs/plans/2026-06-13-cached-response-validation.md
+++ b/docs/plans/2026-06-13-cached-response-validation.md
@@ -1,0 +1,54 @@
+# Validate Cached Response Data
+
+status: planned
+
+## Context
+
+`get_cached_response` validates cache expiry but returns any remaining DynamoDB
+item shape. `/ask` then indexes `response` and `links` directly, so malformed or
+legacy entries can turn an otherwise valid request into a generic 500 instead
+of a cache miss. Cached links also bypass the HTTPS Twilio-host policy applied
+to newly retrieved citations, allowing pre-hardening cache data to retain a
+different trust boundary from fresh responses.
+
+## Priority
+
+Every authenticated `/ask` request checks DynamoDB before retrieval or model
+work. Persisted data must be treated as untrusted at read time, and cache hits
+must preserve the same citation policy as freshly generated answers.
+
+## Scope
+
+1. Accept cache hits only when `response` is a string and `links` is a list of
+   strings; treat missing or malformed payload fields as a cache miss.
+2. Centralize HTTPS Twilio citation filtering and apply it to both fresh
+   retrieval results and valid cache hits.
+3. Add cache and route regressions for malformed entries, legacy external
+   links, duplicate links, and model-work avoidance on a valid cache hit.
+4. Extend the maintained baseline and synchronize cache-boundary documentation.
+
+## Verification Plan
+
+- Run focused and full API tests, compilation, dependency consistency, all
+  standard Make gates including `make verify` and `make package-check`, shell
+  syntax, diff checks, and intended-file artifact and secret scans.
+- Remove cache payload validation, bypass cached-link filtering, and remove each
+  regression contract; every hostile mutation must fail.
+- Push a stacked pull request and take bounded exact-head workflow, check, and
+  CodeQL snapshots without an unbounded polling loop.
+
+## Risk And Rollback
+
+Malformed entries become misses and may trigger a fresh paid model request;
+valid entries keep the existing table schema and response body. Legacy cached
+links outside the current Twilio policy are omitted. Rollback restores direct
+trust in persisted cache payloads and their historical links; no migration is
+required.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and verification.

--- a/docs/plans/2026-06-13-cached-response-validation.md
+++ b/docs/plans/2026-06-13-cached-response-validation.md
@@ -1,6 +1,6 @@
 # Validate Cached Response Data
 
-status: planned
+status: completed
 
 ## Context
 
@@ -47,8 +47,27 @@ required.
 
 ## Work Completed
 
-Pending implementation.
+- Required cache entries to contain a string `response` and a list of string
+  `links`; malformed persisted payloads now become cache misses.
+- Centralized deterministic HTTPS Twilio-host filtering and applied it to both
+  fresh retrieval results and valid cache hits.
+- Added direct cache-shape coverage and an authenticated route regression that
+  removes legacy external, HTTP, and duplicate links without invoking model or
+  cache-write work.
+- Extended the maintained source/test contracts and synchronized the README,
+  vision, and change history.
 
 ## Verification Completed
 
-Pending implementation and verification.
+- The focused malformed-cache and cached-citation tests passed.
+- All 44 API tests and every Make gate passed in an isolated Python 3.10
+  environment with no broken requirements.
+- Credential-isolated Chalice package verification passed with 5,335 archive
+  entries and one scoped Python 3.10 function.
+- Cache payload-validation removal failed all five malformed-shape subtests.
+- Cached-link filtering removal failed the authenticated route regression.
+- Regression-test removal failed the maintained route-test contract.
+- Python compilation, shell syntax, diff checks, intended-file artifact checks,
+  and secret-pattern scans passed.
+- The hosted pull-request and CodeQL snapshot is recorded separately after
+  push; this plan claims only the completed pre-push verification above.

--- a/docs/plans/2026-06-13-total-retrieval-context-boundary.md
+++ b/docs/plans/2026-06-13-total-retrieval-context-boundary.md
@@ -1,6 +1,6 @@
 # Total Retrieval Context Boundary
 
-status: in_progress
+status: completed
 
 ## Context
 
@@ -40,3 +40,26 @@ Queries with more than 4,000 total retrieval characters will send less provider
 context to OpenAI. Match order and the original user query remain unchanged.
 Rollback restores the multiplied context size; there is no stored-data or API
 schema migration.
+
+## Work Completed
+
+- Added a remaining-length budget shared across every accepted Pinecone match.
+- Counted inter-context separators against the same 4,000-character budget.
+- Truncated only the final included context and stopped before later matches.
+- Returned links only for contexts included in the generated prompt.
+- Added focused multi-match coverage and synchronized the canonical baseline and
+  project guidance.
+
+## Verification Completed
+
+- The focused aggregate-context test passed.
+- The aggregate-budget removal mutation failed the total-budget contract.
+- The separator-accounting mutation failed the total-budget contract.
+- The regression-test removal mutation failed the route-test contract.
+- All 42 API tests passed.
+- The isolated Python 3.10 dependency check and Chalice package verification
+  passed with 5,335 archive entries and one scoped function.
+- The all API tests and every Make gate passed under the isolated Python 3.10
+  environment.
+- The hosted pull-request and CodeQL snapshot is recorded separately after push;
+  this plan claims only the completed pre-push verification above.

--- a/docs/plans/2026-06-13-total-retrieval-context-boundary.md
+++ b/docs/plans/2026-06-13-total-retrieval-context-boundary.md
@@ -1,0 +1,42 @@
+# Total Retrieval Context Boundary
+
+status: in_progress
+
+## Context
+
+`metadata_text_and_url` caps each Pinecone match at 4,000 characters, but
+`make_query` can join up to five matches before calling OpenAI. The actual model
+input can therefore contain roughly 20,000 retrieval characters plus separators
+and the user query despite the documented 4,000-character retrieval boundary.
+
+## Priority
+
+This is a direct external-AI cost, latency, and availability boundary on an
+authenticated route. A single total budget is more defensible than multiplying
+the nominal limit by the provider result count.
+
+## Scope
+
+1. Apply `MAX_RETRIEVAL_CONTEXT_LENGTH` to the complete joined retrieval
+   context, including separators.
+2. Preserve match order and truncate only the final included context needed to
+   fill the remaining budget.
+3. Return links only for contexts included in the generated prompt.
+4. Add focused multi-match, separator, truncation, and excluded-link coverage.
+5. Extend the baseline and synchronize README, SECURITY, VISION, and CHANGES.
+
+## Verification Plan
+
+- Run focused and all API tests, Python compilation, every Make gate, package
+  verification, shell syntax, diff checks, and intended-file secret scans.
+- Remove the aggregate budget, exclude separator accounting, and remove the
+  regression test; each hostile mutation must fail.
+- Push a stacked pull request and take one bounded exact-head workflow, check,
+  and CodeQL snapshot without polling.
+
+## Risk And Rollback
+
+Queries with more than 4,000 total retrieval characters will send less provider
+context to OpenAI. Match order and the original user query remain unchanged.
+Rollback restores the multiplied context size; there is no stored-data or API
+schema migration.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -42,6 +42,7 @@ VERCEL_CONFIG="$ROOT_DIR/vercel.json"
 VERCEL_PLAN="$ROOT_DIR/docs/plans/2026-06-12-vercel-deployment-ownership.md"
 PIP_BOOTSTRAP_PLAN="$ROOT_DIR/docs/plans/2026-06-12-pip-bootstrap-pin.md"
 TOTAL_RETRIEVAL_CONTEXT_PLAN="$ROOT_DIR/docs/plans/2026-06-13-total-retrieval-context-boundary.md"
+CACHE_RESPONSE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-cached-response-validation.md"
 
 require_file() {
   path=$1
@@ -309,7 +310,7 @@ if ! grep -Fq "def is_twilio_doc_url(url)" "$APP" ||
   ! grep -Fq "filtered_urls = []" "$APP" ||
   ! grep -Fq "if is_twilio_doc_url(url) and url not in filtered_urls:" "$APP" ||
   ! grep -Fq "filtered_urls.append(url)" "$APP" ||
-  ! grep -Fq "urls = sorted(filtered_urls)" "$APP"; then
+  ! grep -Fq "return sorted(filtered_urls)" "$APP"; then
   printf '%s\n' "Generated answer links must be filtered by HTTPS Twilio host." >&2
   exit 1
 fi
@@ -349,6 +350,7 @@ if ! grep -Fq "test_ask_rejects_unauthenticated_callers_before_body_or_model_wor
   ! grep -Fq "test_serve_public_rejects_path_traversal" "$TEST_APP_AUTH" ||
   ! grep -Fq "test_is_twilio_doc_url_requires_https_twilio_host" "$TEST_APP_AUTH" ||
   ! grep -Fq "test_make_query_filters_links_by_twilio_host" "$TEST_APP_AUTH" ||
+  ! grep -Fq "test_ask_reapplies_twilio_link_policy_to_cached_response" "$TEST_APP_AUTH" ||
   ! grep -Fq "test_make_query_skips_incomplete_metadata" "$TEST_APP_AUTH" ||
   ! grep -Fq "test_make_query_truncates_overlong_metadata_text" "$TEST_APP_AUTH" ||
   ! grep -Fq "test_make_query_bounds_total_context_and_excludes_unused_links" "$TEST_APP_AUTH" ||
@@ -356,6 +358,16 @@ if ! grep -Fq "test_ask_rejects_unauthenticated_callers_before_body_or_model_wor
   ! grep -Fq "test_classify_returns_generic_error_for_unexpected_failures" "$TEST_APP_AUTH" ||
   ! grep -Fq "assert_not_called" "$TEST_APP_AUTH"; then
   printf '%s\n' "Route tests must cover auth short-circuiting and public-file safety." >&2
+  exit 1
+fi
+
+if ! grep -Fq "def filter_twilio_doc_urls(urls):" "$APP" ||
+  [ "$(grep -Fc 'filter_twilio_doc_urls(' "$APP")" -ne 3 ] ||
+  ! grep -Fq "cache_entry.get('response')" "$CACHE" ||
+  ! grep -Fq "cache_entry.get('links')" "$CACHE" ||
+  ! grep -Fq "any(not isinstance(link, str) for link in links)" "$CACHE" ||
+  ! grep -Fq "test_get_cached_response_rejects_malformed_payload_shape" "$TEST_CACHE"; then
+  printf '%s\n' "Cache hits must validate payload shape and reuse the current Twilio citation policy." >&2
   exit 1
 fi
 
@@ -523,6 +535,7 @@ if ! grep -Fq "status: completed" "$PLAN" ||
   ! grep -Fq "status: completed" "$VENDOR_CLEANUP_PLAN" ||
   ! grep -Fq "status: completed" "$VERCEL_PLAN" ||
   ! grep -Fq "status: completed" "$TOTAL_RETRIEVAL_CONTEXT_PLAN" ||
+  ! grep -Fq "status: completed" "$CACHE_RESPONSE_PLAN" ||
   ! grep -Fq "status: completed" "$ROOT_DIR/docs/plans/2026-06-09-twilio-link-host-filtering.md"; then
   printf '%s\n' "Plan documents must be marked completed." >&2
   exit 1
@@ -559,6 +572,34 @@ if (
 ):
     raise SystemExit(
         "Total retrieval-context plan must record completed status and actual verification."
+    )
+PY
+
+python - "$CACHE_RESPONSE_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text(encoding="utf-8")
+statuses = re.findall(r"^status: .+$", plan, flags=re.MULTILINE)
+sections = plan.split("## Verification Completed\n", 1)
+verification = sections[1] if len(sections) == 2 else ""
+required = (
+    "focused malformed-cache and cached-citation tests passed",
+    "All 44 API tests and every Make gate passed",
+    "Cache payload-validation removal failed",
+    "Cached-link filtering removal failed",
+    "Regression-test removal failed",
+    "hosted pull-request and CodeQL snapshot",
+)
+
+if (
+    statuses != ["status: completed"]
+    or any(item not in verification for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Cached-response plan must record completed status and actual verification."
     )
 PY
 

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -41,6 +41,7 @@ PACKAGE_CHECK="$ROOT_DIR/scripts/verify-chalice-package.sh"
 VERCEL_CONFIG="$ROOT_DIR/vercel.json"
 VERCEL_PLAN="$ROOT_DIR/docs/plans/2026-06-12-vercel-deployment-ownership.md"
 PIP_BOOTSTRAP_PLAN="$ROOT_DIR/docs/plans/2026-06-12-pip-bootstrap-pin.md"
+TOTAL_RETRIEVAL_CONTEXT_PLAN="$ROOT_DIR/docs/plans/2026-06-13-total-retrieval-context-boundary.md"
 
 require_file() {
   path=$1
@@ -89,6 +90,7 @@ for path in \
   "docs/plans/2026-06-12-chalice-vendor-cleanup.md" \
   "docs/plans/2026-06-12-vercel-deployment-ownership.md" \
   "docs/plans/2026-06-12-pip-bootstrap-pin.md" \
+  "docs/plans/2026-06-13-total-retrieval-context-boundary.md" \
   "scripts/check-extension-rendering.sh" \
   "scripts/verify-chalice-package.sh" \
   "scripts/check-baseline.sh"; do
@@ -323,6 +325,16 @@ if ! grep -Fq "def metadata_text_and_url(item)" "$APP" ||
   exit 1
 fi
 
+if ! grep -Fq 'RETRIEVAL_CONTEXT_SEPARATOR = "\n\n---\n\n"' "$APP" ||
+  ! grep -Fq "remaining_context_length = MAX_RETRIEVAL_CONTEXT_LENGTH" "$APP" ||
+  ! grep -Fq "available_length = remaining_context_length - separator_length" "$APP" ||
+  ! grep -Fq "bounded_context = context[:available_length]" "$APP" ||
+  ! grep -Fq "remaining_context_length -= separator_length + len(bounded_context)" "$APP" ||
+  ! grep -Fq "if remaining_context_length == 0:" "$APP"; then
+  printf '%s\n' "Retrieval context must enforce one separator-aware total prompt budget." >&2
+  exit 1
+fi
+
 if ! grep -Fq "logger.exception('Failed to process ask request')" "$APP" ||
   ! grep -Fq "logger.exception('Failed to process classify request')" "$APP" ||
   ! grep -Fq "{'error': 'Internal server error'}" "$APP"; then
@@ -339,6 +351,7 @@ if ! grep -Fq "test_ask_rejects_unauthenticated_callers_before_body_or_model_wor
   ! grep -Fq "test_make_query_filters_links_by_twilio_host" "$TEST_APP_AUTH" ||
   ! grep -Fq "test_make_query_skips_incomplete_metadata" "$TEST_APP_AUTH" ||
   ! grep -Fq "test_make_query_truncates_overlong_metadata_text" "$TEST_APP_AUTH" ||
+  ! grep -Fq "test_make_query_bounds_total_context_and_excludes_unused_links" "$TEST_APP_AUTH" ||
   ! grep -Fq "test_ask_returns_generic_error_for_unexpected_failures" "$TEST_APP_AUTH" ||
   ! grep -Fq "test_classify_returns_generic_error_for_unexpected_failures" "$TEST_APP_AUTH" ||
   ! grep -Fq "assert_not_called" "$TEST_APP_AUTH"; then
@@ -427,6 +440,7 @@ if ! grep -Fq "make verify" "$README" ||
   ! grep -Fq "Twilio link host filtering" "$README" ||
   ! grep -Fq "retrieval metadata guard" "$README" ||
   ! grep -Fq "retrieval context length" "$README" ||
+  ! grep -Fq "total retrieval context budget" "$README" ||
   ! grep -Fq "expires_at" "$README" ||
   ! grep -Fq "fixed-size SHA-256 identity" "$README" ||
   ! grep -Fq "generic 500 errors" "$README" ||
@@ -449,6 +463,7 @@ if ! grep -Fq "Run \`make verify\`" "$VISION" ||
   ! grep -Fq "Twilio link host filtering" "$VISION" ||
   ! grep -Fq "retrieval metadata guard" "$VISION" ||
   ! grep -Fq "retrieval context length" "$VISION" ||
+  ! grep -Fq "total retrieval context budget" "$VISION" ||
   ! grep -Fq "cache expiration" "$VISION" ||
   ! grep -Fq "fixed-size SHA-256 cache keys" "$VISION" ||
   ! grep -Fq "text-only extension rendering" "$VISION" ||
@@ -475,6 +490,7 @@ if ! grep -Fq "source baseline guard" "$CHANGES" ||
   ! grep -Fq "Twilio link host filtering" "$CHANGES" ||
   ! grep -Fq "retrieval metadata guard" "$CHANGES" ||
   ! grep -Fq "retrieval context length" "$CHANGES" ||
+  ! grep -Fq "total retrieval context budget" "$CHANGES" ||
   ! grep -Fq "cache entries" "$CHANGES" ||
   ! grep -Fq "SHA-256 identities" "$CHANGES" ||
   ! grep -Fq "text-only DOM rendering" "$CHANGES" ||
@@ -506,6 +522,7 @@ if ! grep -Fq "status: completed" "$PLAN" ||
   ! grep -Fq "status: completed" "$EXTENSION_RENDERING_PLAN" ||
   ! grep -Fq "status: completed" "$VENDOR_CLEANUP_PLAN" ||
   ! grep -Fq "status: completed" "$VERCEL_PLAN" ||
+  ! grep -Fq "status: completed" "$TOTAL_RETRIEVAL_CONTEXT_PLAN" ||
   ! grep -Fq "status: completed" "$ROOT_DIR/docs/plans/2026-06-09-twilio-link-host-filtering.md"; then
   printf '%s\n' "Plan documents must be marked completed." >&2
   exit 1
@@ -516,6 +533,34 @@ if ! grep -Fq "Verified Chalice deployment package" "$VENDOR_CLEANUP_PLAN" ||
   printf '%s\n' "Chalice vendor cleanup plan must record completed package and mutation evidence." >&2
   exit 1
 fi
+
+python - "$TOTAL_RETRIEVAL_CONTEXT_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text(encoding="utf-8")
+statuses = re.findall(r"^status: .+$", plan, flags=re.MULTILINE)
+sections = plan.split("## Verification Completed\n", 1)
+verification = sections[1] if len(sections) == 2 else ""
+required = (
+    "focused aggregate-context test passed",
+    "all API tests and every Make gate passed",
+    "aggregate-budget removal mutation failed",
+    "separator-accounting mutation failed",
+    "regression-test removal mutation failed",
+    "hosted pull-request and CodeQL snapshot",
+)
+
+if (
+    statuses != ["status: completed"]
+    or any(item not in verification for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Total retrieval-context plan must record completed status and actual verification."
+    )
+PY
 
 python - "$VERCEL_PLAN" <<'PY'
 import re


### PR DESCRIPTION
## Summary

Validate persisted generated-answer cache entries before route use and reapply the current HTTPS Twilio citation policy to cache hits.

## Baseline

The cache previously validated only `expires_at`. A malformed valid-TTL item could trigger a route-level 500, while links written before citation hardening bypassed the filter applied to fresh Pinecone results.

## Improvements

- require a string `response` and a list of string `links` on cache hits
- treat malformed persisted payloads as cache misses
- centralize deterministic HTTPS Twilio-host filtering
- apply the shared filter to fresh retrievals and cached citations
- add cache, route, static-contract, and completed-plan regressions

## Validation

- all 44 API tests passed under isolated Python 3.10
- isolated `pip check` reported no broken requirements
- `make lint`, `make test`, `make build`, `make check`, and `make verify` passed
- credential-isolated `make package-check` verified a 5,335-entry Python 3.10 Chalice package with scoped cache access
- cache-validation removal, cached-link filtering removal, and regression removal mutations failed as expected
- shell syntax, diff, artifact, and intended-diff secret checks passed

## Risk

Malformed cache entries now trigger fresh model work, and legacy non-Twilio citations are omitted. The DynamoDB table, key schema, TTL, API response shape, and fresh retrieval behavior remain unchanged.

## Follow-Ups

PR #24 must merge first. This PR should then be refreshed and revalidated against its updated base before any separately authorized merge; no live AWS, OpenAI, Pinecone, or production credentials were exercised.
