### PR TITLE
fix: keep cache failures from blocking answers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@
 - Set `OPENAI_API_KEY`, `PINECONE_API_KEY`, `PINECONE_ENVIRONMENT`, and AWS credentials only in local or deployment environment configuration.
 - Keep `/ask` and `/classify/builder` behind the shared caller API-key guard or a stronger API Gateway/JWT authorizer. Public asset routes may remain unauthenticated, but public asset routes must stay path-bound to `api/chalicelib/public`.
 - Keep request query validation bounded by a maximum query length before routes invoke OpenAI, Pinecone, DynamoDB, or cache helpers.
+- Keep DynamoDB response caching best-effort: cache read failures must continue to fresh retrieval, and cache write failures must not discard a generated response.
 - Keep the classification weight schema limited to numeric `with_code`, `minimal_code`, and `no_code` values.
 - Chalice installs deployable dependencies from `api/requirements.txt`; do not
   commit generated `api/vendor/` content, Python bytecode, caches, or package

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Validated cached response payloads and reapplied HTTPS Twilio citation
+  filtering to cache hits so legacy data cannot bypass current link policy.
 - Enforced one separator-aware 4,000-character total retrieval context budget
   across all Pinecone matches before OpenAI prompt assembly.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Made DynamoDB response caching best-effort so transient read failures bypass
+  the cache and write failures do not discard successfully generated answers.
 - Validated cached response payloads and reapplied HTTPS Twilio citation
   filtering to cache hits so legacy data cannot bypass current link policy.
 - Enforced one separator-aware 4,000-character total retrieval context budget

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   length failures for accepted long or Unicode queries.
 - Cache hits require string responses and string-list links, and cached links
   are rechecked against the current HTTPS Twilio-host citation policy.
+- Cache availability is not required for fresh answers: read failures fall
+  through to retrieval, and write failures are logged after generation.
 - Keep the classification weight schema limited to numeric `with_code`,
   `minimal_code`, and `no_code` values.
 - Twilio link host filtering keeps generated answer links limited to HTTPS

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - Cache reads and writes use a fixed-size SHA-256 identity in the existing
   `query_string` key attribute, avoiding raw user questions and DynamoDB key
   length failures for accepted long or Unicode queries.
+- Cache hits require string responses and string-list links, and cached links
+  are rechecked against the current HTTPS Twilio-host citation policy.
 - Keep the classification weight schema limited to numeric `with_code`,
   `minimal_code`, and `no_code` values.
 - Twilio link host filtering keeps generated answer links limited to HTTPS

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -82,6 +82,11 @@ The maintained `api/iam-policy.json` grants runtime cache access only through
 standard CloudWatch Logs writes required by Lambda. Package verification must
 confirm those permissions are present in the generated SAM role.
 
+DynamoDB response caching is best-effort. A cache read failure must not block
+fresh authenticated retrieval, and a cache write failure must not replace a
+successfully generated answer with a route-level error. Operators should alert
+on cache exception logs because bypassed reads can increase paid upstream work.
+
 ## Safe Research Guidelines
 
 Good-faith research is welcome when it stays within these boundaries:

--- a/VISION.md
+++ b/VISION.md
@@ -30,6 +30,7 @@ Priority:
 - Preserve one-day cache expiration and the DynamoDB `expires_at` TTL attribute
 - Preserve fixed-size SHA-256 cache keys so raw user queries are not DynamoDB
   partition-key material
+- Treat malformed cache payloads as misses and revalidate cached citations
 - Keep unexpected route failures behind generic 500 errors
 - Keep request validation bounded by a maximum query length before model work
 - Keep the classification weight schema explicit and numeric before returning

--- a/VISION.md
+++ b/VISION.md
@@ -31,6 +31,7 @@ Priority:
 - Preserve fixed-size SHA-256 cache keys so raw user queries are not DynamoDB
   partition-key material
 - Treat malformed cache payloads as misses and revalidate cached citations
+- Keep cache backend failures from blocking fresh or already generated answers
 - Keep unexpected route failures behind generic 500 errors
 - Keep request validation bounded by a maximum query length before model work
 - Keep the classification weight schema explicit and numeric before returning
@@ -73,6 +74,8 @@ Contribution rules:
 - Keep cache expiration enforced before returning generated-answer entries.
 - Keep cache reads and writes on the same namespaced query digest while
   retaining the existing DynamoDB table and `query_string` attribute.
+- Keep cache reads and writes best-effort while logging backend failures for
+  operational monitoring.
 - Keep unexpected route failures logged server-side while returning generic 500
   errors to callers.
 - Keep the maximum query length guard in request validation.

--- a/api/app.py
+++ b/api/app.py
@@ -97,6 +97,15 @@ def is_twilio_doc_url(url):
     )
 
 
+def filter_twilio_doc_urls(urls):
+    """Return unique HTTPS Twilio documentation links in deterministic order."""
+    filtered_urls = []
+    for url in urls:
+        if is_twilio_doc_url(url) and url not in filtered_urls:
+            filtered_urls.append(url)
+    return sorted(filtered_urls)
+
+
 def metadata_text_and_url(item):
     """Return usable retrieval context and URL metadata from a Pinecone match."""
     metadata = item.get('metadata') if isinstance(item, dict) else getattr(
@@ -238,11 +247,7 @@ def make_query(query: str) -> Tuple[str, List[str]]:
     response = generate_response(augmented_query)
 
     # Keep this explicit loop compatible with Chalice's IAM policy analyzer.
-    filtered_urls = []
-    for url in urls:
-        if is_twilio_doc_url(url) and url not in filtered_urls:
-            filtered_urls.append(url)
-    urls = sorted(filtered_urls)
+    urls = filter_twilio_doc_urls(urls)
 
     return response, urls
 
@@ -286,7 +291,8 @@ def ask_question():
         cache_entry = get_cached_response(query)
         if cache_entry:
             return Response(body={'response': cache_entry['response'],
-                                  'links': cache_entry['links']},
+                                  'links': filter_twilio_doc_urls(
+                                      cache_entry['links'])},
                             status_code=200)
 
         # Get the response and links using the make_query function

--- a/api/app.py
+++ b/api/app.py
@@ -288,7 +288,11 @@ def ask_question():
             return Response(body={'error': str(error)}, status_code=400)
 
         # Check cache for a matching query
-        cache_entry = get_cached_response(query)
+        try:
+            cache_entry = get_cached_response(query)
+        except Exception:
+            logger.exception('Failed to read response cache; bypassing cache')
+            cache_entry = None
         if cache_entry:
             return Response(body={'response': cache_entry['response'],
                                   'links': filter_twilio_doc_urls(
@@ -299,7 +303,12 @@ def ask_question():
         response, links = make_query(query)
 
         # Push the cache entry to the cache
-        store_in_cache(query, response, links)
+        try:
+            store_in_cache(query, response, links)
+        except Exception:
+            logger.exception(
+                'Failed to write response cache; returning generated response'
+            )
 
         # Create a JSON response with the response and links
         resp = Response(body={'response': response,

--- a/api/chalicelib/cache.py
+++ b/api/chalicelib/cache.py
@@ -43,6 +43,12 @@ def get_cached_response(query, table=None, now=None):
     if expires_at <= current_time:
         return None
 
+    response = cache_entry.get('response')
+    links = cache_entry.get('links')
+    if (not isinstance(response, str) or not isinstance(links, list) or
+            any(not isinstance(link, str) for link in links)):
+        return None
+
     return cache_entry
 
 

--- a/api/tests/test_app_auth.py
+++ b/api/tests/test_app_auth.py
@@ -174,6 +174,74 @@ class AppAuthTests(unittest.TestCase):
         make_query.assert_not_called()
         cache.assert_not_called()
 
+    def test_ask_bypasses_cache_read_failure(self):
+        request = FakeRequest(
+            headers={GPT_DOCS_API_KEY_HEADER: "server-key"},
+            json_body={"query": "How?"},
+        )
+        self.app_module.app.current_request = request
+
+        with patch.dict(os.environ, {GPT_DOCS_API_KEY_ENV: "server-key"}):
+            with patch.object(
+                self.app_module,
+                "get_cached_response",
+                side_effect=RuntimeError("dynamodb unavailable"),
+            ):
+                with patch.object(
+                    self.app_module,
+                    "make_query",
+                    return_value=("answer", ["https://twilio.com/docs"]),
+                ) as make_query:
+                    with patch.object(self.app_module, "store_in_cache") as cache:
+                        with patch.object(
+                            self.app_module.logger, "exception"
+                        ) as log:
+                            response = self.app_module.ask_question()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.body,
+            {"response": "answer", "links": ["https://twilio.com/docs"]},
+        )
+        make_query.assert_called_once_with("How?")
+        cache.assert_called_once_with("How?", "answer", ["https://twilio.com/docs"])
+        log.assert_called_once_with(
+            "Failed to read response cache; bypassing cache"
+        )
+
+    def test_ask_returns_generated_response_when_cache_write_fails(self):
+        request = FakeRequest(
+            headers={GPT_DOCS_API_KEY_HEADER: "server-key"},
+            json_body={"query": "How?"},
+        )
+        self.app_module.app.current_request = request
+
+        with patch.dict(os.environ, {GPT_DOCS_API_KEY_ENV: "server-key"}):
+            with patch.object(self.app_module, "get_cached_response", return_value=None):
+                with patch.object(
+                    self.app_module,
+                    "make_query",
+                    return_value=("answer", ["https://twilio.com/docs"]),
+                ):
+                    with patch.object(
+                        self.app_module,
+                        "store_in_cache",
+                        side_effect=RuntimeError("dynamodb unavailable"),
+                    ):
+                        with patch.object(
+                            self.app_module.logger, "exception"
+                        ) as log:
+                            response = self.app_module.ask_question()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.body,
+            {"response": "answer", "links": ["https://twilio.com/docs"]},
+        )
+        log.assert_called_once_with(
+            "Failed to write response cache; returning generated response"
+        )
+
     def test_ask_returns_generic_error_for_unexpected_failures(self):
         request = FakeRequest(
             headers={GPT_DOCS_API_KEY_HEADER: "server-key"},

--- a/api/tests/test_app_auth.py
+++ b/api/tests/test_app_auth.py
@@ -129,6 +129,51 @@ class AppAuthTests(unittest.TestCase):
         make_query.assert_called_once_with("How?")
         cache.assert_called_once_with("How?", "answer", ["https://twilio.com/docs"])
 
+    def test_ask_reapplies_twilio_link_policy_to_cached_response(self):
+        request = FakeRequest(
+            headers={GPT_DOCS_API_KEY_HEADER: "server-key"},
+            json_body={"query": "How?"},
+        )
+        self.app_module.app.current_request = request
+        cached_response = {
+            "response": "cached answer",
+            "links": [
+                "https://www.twilio.com/docs/b",
+                "https://example.com/?next=twilio.com",
+                "http://www.twilio.com/docs/a",
+                "https://docs.twilio.com/reference",
+                "https://www.twilio.com/docs/b",
+            ],
+        }
+
+        with patch.dict(os.environ, {GPT_DOCS_API_KEY_ENV: "server-key"}):
+            with patch.object(
+                self.app_module,
+                "get_cached_response",
+                return_value=cached_response,
+            ):
+                with patch.object(
+                    self.app_module,
+                    "make_query",
+                    side_effect=AssertionError("should not run"),
+                ) as make_query:
+                    with patch.object(self.app_module, "store_in_cache") as cache:
+                        response = self.app_module.ask_question()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.body,
+            {
+                "response": "cached answer",
+                "links": [
+                    "https://docs.twilio.com/reference",
+                    "https://www.twilio.com/docs/b",
+                ],
+            },
+        )
+        make_query.assert_not_called()
+        cache.assert_not_called()
+
     def test_ask_returns_generic_error_for_unexpected_failures(self):
         request = FakeRequest(
             headers={GPT_DOCS_API_KEY_HEADER: "server-key"},

--- a/api/tests/test_cache.py
+++ b/api/tests/test_cache.py
@@ -91,6 +91,23 @@ class CacheTests(unittest.TestCase):
         self.assertIsNone(get_cached_response("expired", table=expired, now=100))
         self.assertIsNone(get_cached_response("legacy", table=missing_expiry, now=100))
 
+    def test_get_cached_response_rejects_malformed_payload_shape(self):
+        from chalicelib.cache import get_cached_response
+
+        malformed_items = [
+            {"links": ["url"], "expires_at": 200},
+            {"response": 123, "links": ["url"], "expires_at": 200},
+            {"response": "answer", "expires_at": 200},
+            {"response": "answer", "links": "url", "expires_at": 200},
+            {"response": "answer", "links": [123], "expires_at": 200},
+        ]
+
+        for item in malformed_items:
+            with self.subTest(item=item):
+                self.assertIsNone(
+                    get_cached_response("legacy", table=FakeTable(item), now=100)
+                )
+
     def test_store_in_cache_writes_existing_item_shape(self):
         from chalicelib.cache import cache_key, store_in_cache
 

--- a/docs/plans/2026-06-13-cached-response-validation.md
+++ b/docs/plans/2026-06-13-cached-response-validation.md
@@ -1,0 +1,54 @@
+# Validate Cached Response Data
+
+status: planned
+
+## Context
+
+`get_cached_response` validates cache expiry but returns any remaining DynamoDB
+item shape. `/ask` then indexes `response` and `links` directly, so malformed or
+legacy entries can turn an otherwise valid request into a generic 500 instead
+of a cache miss. Cached links also bypass the HTTPS Twilio-host policy applied
+to newly retrieved citations, allowing pre-hardening cache data to retain a
+different trust boundary from fresh responses.
+
+## Priority
+
+Every authenticated `/ask` request checks DynamoDB before retrieval or model
+work. Persisted data must be treated as untrusted at read time, and cache hits
+must preserve the same citation policy as freshly generated answers.
+
+## Scope
+
+1. Accept cache hits only when `response` is a string and `links` is a list of
+   strings; treat missing or malformed payload fields as a cache miss.
+2. Centralize HTTPS Twilio citation filtering and apply it to both fresh
+   retrieval results and valid cache hits.
+3. Add cache and route regressions for malformed entries, legacy external
+   links, duplicate links, and model-work avoidance on a valid cache hit.
+4. Extend the maintained baseline and synchronize cache-boundary documentation.
+
+## Verification Plan
+
+- Run focused and full API tests, compilation, dependency consistency, all
+  standard Make gates including `make verify` and `make package-check`, shell
+  syntax, diff checks, and intended-file artifact and secret scans.
+- Remove cache payload validation, bypass cached-link filtering, and remove each
+  regression contract; every hostile mutation must fail.
+- Push a stacked pull request and take bounded exact-head workflow, check, and
+  CodeQL snapshots without an unbounded polling loop.
+
+## Risk And Rollback
+
+Malformed entries become misses and may trigger a fresh paid model request;
+valid entries keep the existing table schema and response body. Legacy cached
+links outside the current Twilio policy are omitted. Rollback restores direct
+trust in persisted cache payloads and their historical links; no migration is
+required.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and verification.

--- a/docs/plans/2026-06-13-cached-response-validation.md
+++ b/docs/plans/2026-06-13-cached-response-validation.md
@@ -1,6 +1,6 @@
 # Validate Cached Response Data
 
-status: planned
+status: completed
 
 ## Context
 
@@ -47,8 +47,27 @@ required.
 
 ## Work Completed
 
-Pending implementation.
+- Required cache entries to contain a string `response` and a list of string
+  `links`; malformed persisted payloads now become cache misses.
+- Centralized deterministic HTTPS Twilio-host filtering and applied it to both
+  fresh retrieval results and valid cache hits.
+- Added direct cache-shape coverage and an authenticated route regression that
+  removes legacy external, HTTP, and duplicate links without invoking model or
+  cache-write work.
+- Extended the maintained source/test contracts and synchronized the README,
+  vision, and change history.
 
 ## Verification Completed
 
-Pending implementation and verification.
+- The focused malformed-cache and cached-citation tests passed.
+- All 44 API tests and every Make gate passed in an isolated Python 3.10
+  environment with no broken requirements.
+- Credential-isolated Chalice package verification passed with 5,335 archive
+  entries and one scoped Python 3.10 function.
+- Cache payload-validation removal failed all five malformed-shape subtests.
+- Cached-link filtering removal failed the authenticated route regression.
+- Regression-test removal failed the maintained route-test contract.
+- Python compilation, shell syntax, diff checks, intended-file artifact checks,
+  and secret-pattern scans passed.
+- The hosted pull-request and CodeQL snapshot is recorded separately after
+  push; this plan claims only the completed pre-push verification above.

--- a/docs/plans/2026-06-13-graceful-cache-bypass.md
+++ b/docs/plans/2026-06-13-graceful-cache-bypass.md
@@ -1,6 +1,6 @@
 # Graceful Cache Bypass
 
-status: in_progress
+status: completed
 
 ## Context
 
@@ -43,3 +43,25 @@ unchanged. During a DynamoDB outage, requests can perform fresh paid model work
 instead of failing fast, so operators should monitor cache errors and upstream
 usage. Rollback restores cache failures as route-level 500 responses; no data
 migration exists.
+
+## Work Completed
+
+- Isolated the response-cache read so backend exceptions are logged and treated
+  as cache misses before fresh retrieval.
+- Isolated the response-cache write so backend exceptions are logged after
+  generation without replacing the successful response.
+- Added focused route regressions, AST-backed source contracts, project
+  guidance, and completed-plan evidence requirements.
+
+## Verification Completed
+
+- The focused cache-degradation tests passed.
+- All 46 API tests and every Make gate passed.
+- Python compilation, dependency consistency, shell syntax, `git diff --check`,
+  and intended-file artifact and secret scans passed.
+- The cache-read bypass removal mutation failed.
+- The cache-write isolation removal mutation failed.
+- The read-regression removal mutation failed.
+- The write-regression removal mutation failed.
+- The hosted pull-request and CodeQL snapshot is recorded after the
+  implementation commit using bounded exact-head queries without polling.

--- a/docs/plans/2026-06-13-graceful-cache-bypass.md
+++ b/docs/plans/2026-06-13-graceful-cache-bypass.md
@@ -1,0 +1,45 @@
+# Graceful Cache Bypass
+
+status: in_progress
+
+## Context
+
+Every authenticated `/ask` request reads DynamoDB before retrieval and writes
+the generated answer afterward. A transient cache read currently prevents the
+API from doing useful model work, while a transient cache write discards an
+otherwise successful response after OpenAI and Pinecone work has completed.
+The cache is an optimization, so its availability should not become the
+availability boundary for fresh answers.
+
+## Priority
+
+This is the highest-value remaining isolated route reliability gap. It avoids
+unnecessary 500 responses and repeated paid work without changing request
+authentication, cache identity, TTL behavior, payload validation, retrieval,
+or response shape.
+
+## Scope
+
+1. Treat a cache read exception as a miss and continue to fresh retrieval.
+2. Log a cache write exception and still return the generated response.
+3. Keep malformed or expired cache entries governed by the existing cache
+   helper validation.
+4. Add focused route regressions and mutation-sensitive static contracts.
+
+## Verification Plan
+
+- Run focused route tests, all API tests, every Make gate, Python compilation,
+  dependency consistency, shell syntax, `git diff --check`, and intended-file
+  artifact and secret scans.
+- Remove read bypass, remove write isolation, and remove each focused regression;
+  every hostile mutation must fail.
+- Push a stacked pull request and take one bounded exact-head workflow and
+  code-scanning snapshot without polling.
+
+## Risk And Rollback
+
+Cache hits, valid writes, cache keys, TTLs, and response bodies remain
+unchanged. During a DynamoDB outage, requests can perform fresh paid model work
+instead of failing fast, so operators should monitor cache errors and upstream
+usage. Rollback restores cache failures as route-level 500 responses; no data
+migration exists.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -42,6 +42,7 @@ VERCEL_CONFIG="$ROOT_DIR/vercel.json"
 VERCEL_PLAN="$ROOT_DIR/docs/plans/2026-06-12-vercel-deployment-ownership.md"
 PIP_BOOTSTRAP_PLAN="$ROOT_DIR/docs/plans/2026-06-12-pip-bootstrap-pin.md"
 TOTAL_RETRIEVAL_CONTEXT_PLAN="$ROOT_DIR/docs/plans/2026-06-13-total-retrieval-context-boundary.md"
+CACHE_RESPONSE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-cached-response-validation.md"
 
 require_file() {
   path=$1
@@ -309,7 +310,7 @@ if ! grep -Fq "def is_twilio_doc_url(url)" "$APP" ||
   ! grep -Fq "filtered_urls = []" "$APP" ||
   ! grep -Fq "if is_twilio_doc_url(url) and url not in filtered_urls:" "$APP" ||
   ! grep -Fq "filtered_urls.append(url)" "$APP" ||
-  ! grep -Fq "urls = sorted(filtered_urls)" "$APP"; then
+  ! grep -Fq "return sorted(filtered_urls)" "$APP"; then
   printf '%s\n' "Generated answer links must be filtered by HTTPS Twilio host." >&2
   exit 1
 fi
@@ -349,6 +350,7 @@ if ! grep -Fq "test_ask_rejects_unauthenticated_callers_before_body_or_model_wor
   ! grep -Fq "test_serve_public_rejects_path_traversal" "$TEST_APP_AUTH" ||
   ! grep -Fq "test_is_twilio_doc_url_requires_https_twilio_host" "$TEST_APP_AUTH" ||
   ! grep -Fq "test_make_query_filters_links_by_twilio_host" "$TEST_APP_AUTH" ||
+  ! grep -Fq "test_ask_reapplies_twilio_link_policy_to_cached_response" "$TEST_APP_AUTH" ||
   ! grep -Fq "test_make_query_skips_incomplete_metadata" "$TEST_APP_AUTH" ||
   ! grep -Fq "test_make_query_truncates_overlong_metadata_text" "$TEST_APP_AUTH" ||
   ! grep -Fq "test_make_query_bounds_total_context_and_excludes_unused_links" "$TEST_APP_AUTH" ||
@@ -356,6 +358,16 @@ if ! grep -Fq "test_ask_rejects_unauthenticated_callers_before_body_or_model_wor
   ! grep -Fq "test_classify_returns_generic_error_for_unexpected_failures" "$TEST_APP_AUTH" ||
   ! grep -Fq "assert_not_called" "$TEST_APP_AUTH"; then
   printf '%s\n' "Route tests must cover auth short-circuiting and public-file safety." >&2
+  exit 1
+fi
+
+if ! grep -Fq "def filter_twilio_doc_urls(urls):" "$APP" ||
+  [ "$(grep -Fc 'filter_twilio_doc_urls(' "$APP")" -ne 3 ] ||
+  ! grep -Fq "cache_entry.get('response')" "$CACHE" ||
+  ! grep -Fq "cache_entry.get('links')" "$CACHE" ||
+  ! grep -Fq "any(not isinstance(link, str) for link in links)" "$CACHE" ||
+  ! grep -Fq "test_get_cached_response_rejects_malformed_payload_shape" "$TEST_CACHE"; then
+  printf '%s\n' "Cache hits must validate payload shape and reuse the current Twilio citation policy." >&2
   exit 1
 fi
 
@@ -523,6 +535,7 @@ if ! grep -Fq "status: completed" "$PLAN" ||
   ! grep -Fq "status: completed" "$VENDOR_CLEANUP_PLAN" ||
   ! grep -Fq "status: completed" "$VERCEL_PLAN" ||
   ! grep -Fq "status: completed" "$TOTAL_RETRIEVAL_CONTEXT_PLAN" ||
+  ! grep -Fq "status: completed" "$CACHE_RESPONSE_PLAN" ||
   ! grep -Fq "status: completed" "$ROOT_DIR/docs/plans/2026-06-09-twilio-link-host-filtering.md"; then
   printf '%s\n' "Plan documents must be marked completed." >&2
   exit 1
@@ -559,6 +572,34 @@ if (
 ):
     raise SystemExit(
         "Total retrieval-context plan must record completed status and actual verification."
+    )
+PY
+
+python - "$CACHE_RESPONSE_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text(encoding="utf-8")
+statuses = re.findall(r"^status: .+$", plan, flags=re.MULTILINE)
+sections = plan.split("## Verification Completed\n", 1)
+verification = sections[1] if len(sections) == 2 else ""
+required = (
+    "focused malformed-cache and cached-citation tests passed",
+    "All 44 API tests and every Make gate passed",
+    "Cache payload-validation removal failed",
+    "Cached-link filtering removal failed",
+    "Regression-test removal failed",
+    "hosted pull-request and CodeQL snapshot",
+)
+
+if (
+    statuses != ["status: completed"]
+    or any(item not in verification for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Cached-response plan must record completed status and actual verification."
     )
 PY
 

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -43,6 +43,7 @@ VERCEL_PLAN="$ROOT_DIR/docs/plans/2026-06-12-vercel-deployment-ownership.md"
 PIP_BOOTSTRAP_PLAN="$ROOT_DIR/docs/plans/2026-06-12-pip-bootstrap-pin.md"
 TOTAL_RETRIEVAL_CONTEXT_PLAN="$ROOT_DIR/docs/plans/2026-06-13-total-retrieval-context-boundary.md"
 CACHE_RESPONSE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-cached-response-validation.md"
+GRACEFUL_CACHE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-graceful-cache-bypass.md"
 
 require_file() {
   path=$1
@@ -92,6 +93,8 @@ for path in \
   "docs/plans/2026-06-12-vercel-deployment-ownership.md" \
   "docs/plans/2026-06-12-pip-bootstrap-pin.md" \
   "docs/plans/2026-06-13-total-retrieval-context-boundary.md" \
+  "docs/plans/2026-06-13-cached-response-validation.md" \
+  "docs/plans/2026-06-13-graceful-cache-bypass.md" \
   "scripts/check-extension-rendering.sh" \
   "scripts/verify-chalice-package.sh" \
   "scripts/check-baseline.sh"; do
@@ -371,6 +374,99 @@ if ! grep -Fq "def filter_twilio_doc_urls(urls):" "$APP" ||
   exit 1
 fi
 
+python - "$APP" "$TEST_APP_AUTH" <<'PY'
+import ast
+import sys
+from pathlib import Path
+
+app_tree = ast.parse(Path(sys.argv[1]).read_text(encoding="utf-8"))
+test_tree = ast.parse(Path(sys.argv[2]).read_text(encoding="utf-8"))
+ask = next(
+    node for node in app_tree.body
+    if isinstance(node, ast.FunctionDef) and node.name == "ask_question"
+)
+
+def calls_name(node, name):
+    return any(
+        isinstance(item, ast.Call)
+        and isinstance(item.func, ast.Name)
+        and item.func.id == name
+        for item in ast.walk(node)
+    )
+
+def exception_handler(try_node):
+    handlers = [
+        handler for handler in try_node.handlers
+        if isinstance(handler.type, ast.Name) and handler.type.id == "Exception"
+    ]
+    if len(handlers) != 1:
+        raise SystemExit("Cache operations must retain one explicit Exception boundary.")
+    return handlers[0]
+
+def logged_message(handler, expected):
+    return any(
+        isinstance(item, ast.Call)
+        and isinstance(item.func, ast.Attribute)
+        and isinstance(item.func.value, ast.Name)
+        and item.func.value.id == "logger"
+        and item.func.attr == "exception"
+        and len(item.args) == 1
+        and isinstance(item.args[0], ast.Constant)
+        and item.args[0].value == expected
+        for item in ast.walk(handler)
+    )
+
+read_candidates = [
+    node for node in ast.walk(ask)
+    if isinstance(node, ast.Try) and calls_name(node, "get_cached_response")
+]
+write_candidates = [
+    node for node in ast.walk(ask)
+    if isinstance(node, ast.Try) and calls_name(node, "store_in_cache")
+]
+read_try = min(
+    read_candidates,
+    key=lambda node: node.end_lineno - node.lineno,
+    default=None,
+)
+write_try = min(
+    write_candidates,
+    key=lambda node: node.end_lineno - node.lineno,
+    default=None,
+)
+if read_try is None or write_try is None or read_try.lineno >= write_try.lineno:
+    raise SystemExit("Cache reads and writes must remain isolated in request order.")
+
+read_handler = exception_handler(read_try)
+read_sets_miss = any(
+    isinstance(item, ast.Assign)
+    and any(isinstance(target, ast.Name) and target.id == "cache_entry" for target in item.targets)
+    and isinstance(item.value, ast.Constant)
+    and item.value.value is None
+    for item in read_handler.body
+)
+if not read_sets_miss or not logged_message(
+    read_handler, "Failed to read response cache; bypassing cache"
+):
+    raise SystemExit("Cache read failures must be logged and converted to misses.")
+
+write_handler = exception_handler(write_try)
+if not logged_message(
+    write_handler, "Failed to write response cache; returning generated response"
+):
+    raise SystemExit("Cache write failures must be logged without replacing the response.")
+
+test_names = {
+    node.name for node in ast.walk(test_tree) if isinstance(node, ast.FunctionDef)
+}
+required_tests = {
+    "test_ask_bypasses_cache_read_failure",
+    "test_ask_returns_generated_response_when_cache_write_fails",
+}
+if not required_tests.issubset(test_names):
+    raise SystemExit("Cache degradation must retain focused route regressions.")
+PY
+
 if ! grep -Fq "def get_cache_table(resource=None)" "$CACHE" ||
   ! grep -Fq "def get_cached_response(query, table=None, now=None)" "$CACHE" ||
   ! grep -Fq "def store_in_cache(query, response, links, table=None, now=None," "$CACHE" ||
@@ -536,6 +632,7 @@ if ! grep -Fq "status: completed" "$PLAN" ||
   ! grep -Fq "status: completed" "$VERCEL_PLAN" ||
   ! grep -Fq "status: completed" "$TOTAL_RETRIEVAL_CONTEXT_PLAN" ||
   ! grep -Fq "status: completed" "$CACHE_RESPONSE_PLAN" ||
+  ! grep -Fq "status: completed" "$GRACEFUL_CACHE_PLAN" ||
   ! grep -Fq "status: completed" "$ROOT_DIR/docs/plans/2026-06-09-twilio-link-host-filtering.md"; then
   printf '%s\n' "Plan documents must be marked completed." >&2
   exit 1
@@ -572,6 +669,35 @@ if (
 ):
     raise SystemExit(
         "Total retrieval-context plan must record completed status and actual verification."
+    )
+PY
+
+python - "$GRACEFUL_CACHE_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text(encoding="utf-8")
+statuses = re.findall(r"^status: .+$", plan, flags=re.MULTILINE)
+sections = plan.split("## Verification Completed\n", 1)
+verification = sections[1] if len(sections) == 2 else ""
+required = (
+    "focused cache-degradation tests passed",
+    "All 46 API tests and every Make gate passed",
+    "cache-read bypass removal mutation failed",
+    "cache-write isolation removal mutation failed",
+    "read-regression removal mutation failed",
+    "write-regression removal mutation failed",
+    "hosted pull-request and CodeQL snapshot",
+)
+
+if (
+    statuses != ["status: completed"]
+    or any(item not in verification for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Graceful cache-bypass plan must record completed status and actual verification."
     )
 PY
 
@@ -639,6 +765,15 @@ fi
 
 if ! grep -Fq "Mutations accepting expired entries or omitting written TTLs must fail" "$CACHE_EXPIRATION_PLAN"; then
   printf '%s\n' "Cache expiration plan must record completed mutation verification." >&2
+  exit 1
+fi
+
+if ! grep -Fq "DynamoDB response caching best-effort" "$ROOT_DIR/AGENTS.md" ||
+  ! grep -Fq "Cache availability is not required for fresh answers" "$README" ||
+  ! grep -Fq "DynamoDB response caching is best-effort" "$ROOT_DIR/SECURITY.md" ||
+  ! grep -Fq "Keep cache backend failures from blocking fresh or already generated answers" "$VISION" ||
+  ! grep -Fq "Made DynamoDB response caching best-effort" "$CHANGES"; then
+  printf '%s\n' "Project guidance must document graceful cache degradation." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Authenticated `/ask` requests now continue to fresh retrieval when DynamoDB cache reads fail, and successfully generated answers are still returned when cache writes fail. The cache remains an optimization instead of becoming the availability boundary for OpenAI and Pinecone-backed responses.

## Baseline

This PR is stacked on PR #25 (`engineering/validate-cached-response-20260613`). Authentication, request validation, cache-hit validation, citations, TTLs, and caller response shapes remain unchanged.

## Improvements

- Degrade failed DynamoDB cache reads to cache misses so fresh retrieval can continue.
- Return successfully generated answers when cache writes fail.
- Log cache exceptions for operational monitoring.
- Keep DynamoDB caching as an optimization rather than an availability requirement for OpenAI and Pinecone-backed responses.

## Validation

- 46 API tests, including focused read- and write-failure regressions.
- `make lint`, `make test`, `make build`, `make check`, and `make verify`.
- Credential-isolated `make package-check` on Python 3.10.19 with 5,335 archive entries and scoped cache access.
- Pinned dependency consistency with no broken requirements.
- Four hostile mutations covering both exception boundaries and both regressions.
- Python and shell syntax, diff hygiene, artifact scan, and intended-file secret scan.
- Compound Engineering review found no actionable findings.
- Browser testing is not applicable because no rendered page, extension asset, or browser interaction changed.

## Risk

A sustained DynamoDB outage can increase paid upstream work because reads degrade to misses. Rollback is limited to this implementation commit and requires no data migration.

## Follow-Ups

- Merge the stack in base order, keeping PR #25 available until this successor is integrated.
- Monitor the new cache exception logs alongside OpenAI and Pinecone usage.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
