### PR TITLE
fix: tolerate retrieval accessor failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,8 @@
 - Keep DynamoDB response caching best-effort: cache read failures must continue to fresh retrieval, and cache write failures must not discard a generated response.
 - Malformed retrieval matches containers must normalize to no matches before
   per-item metadata validation and answer generation.
+- Unusable retrieval response accessors must normalize to no matches before
+  container validation; preserve callable mapping and object attribute forms.
 - Keep the classification weight schema limited to numeric `with_code`, `minimal_code`, and `no_code` values.
 - Chalice installs deployable dependencies from `api/requirements.txt`; do not
   commit generated `api/vendor/` content, Python bytecode, caches, or package

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,8 @@
 - Keep `/ask` and `/classify/builder` behind the shared caller API-key guard or a stronger API Gateway/JWT authorizer. Public asset routes may remain unauthenticated, but public asset routes must stay path-bound to `api/chalicelib/public`.
 - Keep request query validation bounded by a maximum query length before routes invoke OpenAI, Pinecone, DynamoDB, or cache helpers.
 - Keep DynamoDB response caching best-effort: cache read failures must continue to fresh retrieval, and cache write failures must not discard a generated response.
+- Malformed retrieval matches containers must normalize to no matches before
+  per-item metadata validation and answer generation.
 - Keep the classification weight schema limited to numeric `with_code`, `minimal_code`, and `no_code` values.
 - Chalice installs deployable dependencies from `api/requirements.txt`; do not
   commit generated `api/vendor/` content, Python bytecode, caches, or package

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-16
 
+- Normalized non-callable or failing retrieval response accessors to no matches
+  while preserving mapping and object response compatibility.
 - Normalized malformed retrieval matches containers to an empty collection
   before per-item metadata validation.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-16
+
+- Normalized malformed retrieval matches containers to an empty collection
+  before per-item metadata validation.
+
 ## 2026-06-15
 
 - Required binary-only dependency artifacts in hosted installation and Chalice packaging.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   metadata is skipped before answer generation.
 - Malformed retrieval matches containers normalize to no matches before
   metadata iteration, preserving query-only answer generation.
+- Unusable retrieval response accessors normalize to no matches, while
+  callable mapping access and safe object attributes remain supported.
 - Keep the retrieval context length guard in place so oversized Pinecone
   metadata cannot expand generated-answer prompts without bound.
 - Keep the total retrieval context budget shared across all matches, including

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   `twilio.com` or `*.twilio.com` hosts instead of substring matches.
 - Keep the retrieval metadata guard in place so incomplete Pinecone match
   metadata is skipped before answer generation.
+- Malformed retrieval matches containers normalize to no matches before
+  metadata iteration, preserving query-only answer generation.
 - Keep the retrieval context length guard in place so oversized Pinecone
   metadata cannot expand generated-answer prompts without bound.
 - Keep the total retrieval context budget shared across all matches, including

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,8 @@ prompts. Links for excluded context should not be returned as supporting
 sources.
 Malformed retrieval matches containers must normalize to no matches before
 provider-controlled values are iterated.
+Unusable retrieval response accessors must normalize to no matches before
+provider-controlled containers are inspected.
 Generated-answer cache entries should carry a bounded `expires_at` lifetime;
 enable DynamoDB TTL on that attribute so stale query data is physically removed.
 Cache partition keys use a namespaced SHA-256 digest rather than raw user

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,6 +46,8 @@ Retrieved document context should share one separator-aware total length budget
 across all provider matches before it is assembled into generated-answer
 prompts. Links for excluded context should not be returned as supporting
 sources.
+Malformed retrieval matches containers must normalize to no matches before
+provider-controlled values are iterated.
 Generated-answer cache entries should carry a bounded `expires_at` lifetime;
 enable DynamoDB TTL on that attribute so stale query data is physically removed.
 Cache partition keys use a namespaced SHA-256 digest rather than raw user

--- a/VISION.md
+++ b/VISION.md
@@ -25,6 +25,8 @@ Priority:
 - Keep crawling, embedding, retrieval, and answer generation boundaries clear
 - Preserve Twilio link host filtering for generated answer citations
 - Preserve the retrieval metadata guard before answer generation
+- Malformed retrieval matches containers normalize to no matches before
+  metadata iteration and query-only answer generation
 - Preserve the retrieval context length guard before prompt assembly
 - Preserve one total retrieval context budget across all matches and separators
 - Preserve one-day cache expiration and the DynamoDB `expires_at` TTL attribute

--- a/VISION.md
+++ b/VISION.md
@@ -27,6 +27,8 @@ Priority:
 - Preserve the retrieval metadata guard before answer generation
 - Malformed retrieval matches containers normalize to no matches before
   metadata iteration and query-only answer generation
+- Unusable retrieval response accessors normalize to no matches while mapping
+  and object response compatibility remains intact
 - Preserve the retrieval context length guard before prompt assembly
 - Preserve one total retrieval context budget across all matches and separators
 - Preserve one-day cache expiration and the DynamoDB `expires_at` TTL attribute

--- a/api/app.py
+++ b/api/app.py
@@ -131,6 +131,16 @@ def metadata_text_and_url(item):
     return context, url
 
 
+def retrieval_matches(response):
+    """Return Pinecone matches only from a supported collection shape."""
+    matches = response.get('matches', []) if hasattr(response, 'get') else getattr(
+        response, 'matches', []
+    )
+    if not isinstance(matches, (list, tuple)):
+        return ()
+    return matches
+
+
 @app.route('/public/{filename}', methods=['GET'])
 def serve_public(filename):
     """
@@ -220,9 +230,7 @@ def make_query(query: str) -> Tuple[str, List[str]]:
     remaining_context_length = MAX_RETRIEVAL_CONTEXT_LENGTH
 
     # Extract the contexts and URLs from the query results
-    matches = res.get('matches', []) if hasattr(res, 'get') else getattr(
-        res, 'matches', []
-    )
+    matches = retrieval_matches(res)
     for item in matches:
         context, url = metadata_text_and_url(item)
         if context is None:

--- a/api/app.py
+++ b/api/app.py
@@ -133,9 +133,15 @@ def metadata_text_and_url(item):
 
 def retrieval_matches(response):
     """Return Pinecone matches only from a supported collection shape."""
-    matches = response.get('matches', []) if hasattr(response, 'get') else getattr(
-        response, 'matches', []
-    )
+    try:
+        get_matches = getattr(response, 'get', None)
+        if callable(get_matches):
+            matches = get_matches('matches', [])
+        else:
+            matches = getattr(response, 'matches', [])
+    except Exception:
+        return ()
+
     if not isinstance(matches, (list, tuple)):
         return ()
     return matches

--- a/api/tests/test_app_auth.py
+++ b/api/tests/test_app_auth.py
@@ -423,6 +423,42 @@ class AppAuthTests(unittest.TestCase):
             "context a\n\n---\n\ncontext b\n\n-----\n\nHow?",
         )
 
+    def test_make_query_ignores_malformed_matches_containers(self):
+        malformed_matches = (None, "matches", 1, {"metadata": {}})
+
+        for matches in malformed_matches:
+            with self.subTest(matches=matches):
+                class FakeIndex:
+                    def query(self, *args, **kwargs):
+                        return {"matches": matches}
+
+                with patch.object(
+                    self.app_module, "get_embeddings", return_value=[0.1]
+                ):
+                    with patch.object(
+                        self.app_module, "get_index", return_value=FakeIndex()
+                    ):
+                        with patch.object(
+                            self.app_module,
+                            "generate_response",
+                            return_value="answer",
+                        ) as generate_response:
+                            response, links = self.app_module.make_query("How?")
+
+                self.assertEqual(response, "answer")
+                self.assertEqual(links, [])
+                generate_response.assert_called_once_with("\n\n-----\n\nHow?")
+
+    def test_retrieval_matches_accepts_list_and_tuple(self):
+        match = {"metadata": {"text": "context"}}
+
+        self.assertEqual([match], self.app_module.retrieval_matches({
+            "matches": [match]
+        }))
+        self.assertEqual((match,), self.app_module.retrieval_matches(type(
+            "Response", (), {"matches": (match,)}
+        )()))
+
     def test_make_query_truncates_overlong_metadata_text(self):
         long_context = "x" * (self.app_module.MAX_RETRIEVAL_CONTEXT_LENGTH + 25)
 

--- a/api/tests/test_app_auth.py
+++ b/api/tests/test_app_auth.py
@@ -459,6 +459,54 @@ class AppAuthTests(unittest.TestCase):
             "Response", (), {"matches": (match,)}
         )()))
 
+    def test_retrieval_matches_handles_unsupported_accessors(self):
+        match = {"metadata": {"text": "context"}}
+
+        class NonCallableGetResponse:
+            get = None
+            matches = [match]
+
+        class RaisingGetResponse:
+            def get(self, key, default):
+                raise RuntimeError("provider mapping failure")
+
+        class RaisingMatchesResponse:
+            @property
+            def matches(self):
+                raise RuntimeError("provider attribute failure")
+
+        self.assertEqual(
+            [match],
+            self.app_module.retrieval_matches(NonCallableGetResponse()),
+        )
+        self.assertEqual((), self.app_module.retrieval_matches(RaisingGetResponse()))
+        self.assertEqual(
+            (),
+            self.app_module.retrieval_matches(RaisingMatchesResponse()),
+        )
+
+    def test_make_query_uses_query_only_prompt_after_accessor_failure(self):
+        class RaisingGetResponse:
+            def get(self, key, default):
+                raise RuntimeError("provider mapping failure")
+
+        class FakeIndex:
+            def query(self, *args, **kwargs):
+                return RaisingGetResponse()
+
+        with patch.object(self.app_module, "get_embeddings", return_value=[0.1]):
+            with patch.object(self.app_module, "get_index", return_value=FakeIndex()):
+                with patch.object(
+                    self.app_module,
+                    "generate_response",
+                    return_value="answer",
+                ) as generate_response:
+                    response, links = self.app_module.make_query("How?")
+
+        self.assertEqual(response, "answer")
+        self.assertEqual(links, [])
+        generate_response.assert_called_once_with("\n\n-----\n\nHow?")
+
     def test_make_query_truncates_overlong_metadata_text(self):
         long_context = "x" * (self.app_module.MAX_RETRIEVAL_CONTEXT_LENGTH + 25)
 

--- a/docs/plans/2026-06-16-retrieval-matches-container.md
+++ b/docs/plans/2026-06-16-retrieval-matches-container.md
@@ -1,7 +1,7 @@
 ---
 title: Retrieval Matches Container
 date: 2026-06-16
-status: active
+status: completed
 execution: code
 ---
 
@@ -51,8 +51,23 @@ OpenAI, Pinecone, DynamoDB, or AWS calls.
 
 ## Work Completed
 
-Pending implementation.
+- Added `retrieval_matches` to accept list and tuple collections while
+  normalizing malformed top-level provider values to an empty tuple.
+- Routed `make_query` through the helper and added malformed-container
+  characterization, static, guidance, and completed-plan contracts.
 
 ## Verification Completed
 
-Pending implementation and validation.
+- The focused retrieval tests and complete API suite passed with 48 tests.
+- All four Make gates passed in the isolated baseline mirror and final worktree.
+- The external-directory Make gate passed through the absolute Makefile path.
+- The container-guard mutation failed after removing the shape check.
+- The mapping-acceptance mutation failed after treating mappings as match
+  collections.
+- The focused-test contract mutation failed after renaming the malformed
+  matches characterization.
+- The plan-status mutation failed after restoring an active status.
+- The plan-evidence mutation failed after removing the guard-mutation result.
+- Compile, dependency-lock, extension-rendering, diff, generated-artifact,
+  credential, conflict-marker, file-mode, and upstream audits completed before
+  commit.

--- a/docs/plans/2026-06-16-retrieval-matches-container.md
+++ b/docs/plans/2026-06-16-retrieval-matches-container.md
@@ -1,0 +1,58 @@
+---
+title: Retrieval Matches Container
+date: 2026-06-16
+status: active
+execution: code
+---
+
+## Context
+
+`make_query` validates every Pinecone match's metadata, but it iterates the
+top-level `matches` value without checking the container shape. A provider
+response containing `matches: null`, a scalar, or a mapping raises before the
+existing metadata guard can skip malformed items.
+
+## Priority
+
+This is the highest-value remaining deterministic response-shape gap because it
+is controlled by an external retrieval provider, bypasses the established
+per-item resilience boundary, and can be covered without credentials or live
+OpenAI, Pinecone, DynamoDB, or AWS calls.
+
+## Plan
+
+1. Add a small helper that returns only list or tuple match collections and
+   normalizes every other shape to an empty collection.
+2. Route `make_query` through the helper before per-item metadata validation.
+3. Add focused tests for valid mapping/object responses and malformed matches
+   container values while preserving the query-only generated prompt.
+4. Extend the baseline, guidance, changelog, and completed-plan contract.
+5. Run focused and full tests, all Make gates, external-directory validation,
+   isolated mutations, and final artifact/secret/diff audits.
+6. Push the exact branch, open a stacked pull request against the binary-only
+   dependency branch, and take one bounded hosted/security snapshot.
+
+## Non-Goals
+
+- Calling live Pinecone or OpenAI services.
+- Changing per-match metadata, URL filtering, or context-length behavior.
+- Changing dependency locks, binary-only policy, or deployment packaging.
+- Migrating legacy OpenAI or Pinecone client APIs.
+
+## Verification Required
+
+- Focused retrieval tests and the complete API test suite pass.
+- `make check`, `make lint`, `make test`, and `make build` pass from the
+  repository, and the absolute Makefile check passes externally.
+- Mutations removing the container guard, accepting mappings as iterable
+  matches, removing focused coverage, or staling plan evidence fail.
+- Final intended paths pass compile, whitespace, artifact, credential,
+  conflict-marker, file-mode, lock-consistency, and upstream-alignment audits.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and validation.

--- a/docs/plans/2026-06-16-retrieval-response-accessor.md
+++ b/docs/plans/2026-06-16-retrieval-response-accessor.md
@@ -1,0 +1,47 @@
+---
+title: Retrieval Response Accessor Safety
+date: 2026-06-16
+status: planned
+execution: code
+---
+
+## Context
+
+`retrieval_matches()` normalizes malformed `matches` containers, but it first
+uses `hasattr(response, 'get')` and then calls `response.get(...)`
+unconditionally. A provider wrapper with a non-callable `get` attribute, or an
+accessor that raises, fails before the container guard and turns the intended
+query-only fallback into an API error.
+
+## Priority
+
+This is the remaining deterministic boundary immediately before the completed
+matches-container validation. The response is controlled by an external SDK,
+and the behavior can be proved offline without credentials or live services.
+
+## Plan
+
+1. Extract `matches` only through a callable mapping accessor or safe attribute
+   lookup.
+2. Normalize accessor failures and unsupported response shapes to no matches.
+3. Preserve mapping/object list and tuple compatibility, context budgets,
+   citation filtering, and query-only generation.
+4. Add focused runtime tests and mutation-sensitive baseline contracts.
+5. Record actual focused, full-gate, external-directory, review, audit, and
+   hosted verification evidence.
+
+## Verification
+
+- Run focused API tests and the complete `make check`, `make lint`, `make test`,
+  and `make build` gates with explicit timeouts.
+- Run the absolute-Makefile check from an external directory.
+- Reject mutations that restore unconditional `.get`, propagate accessor
+  failures, remove focused tests, or reopen completed plan evidence.
+- Audit exact diff, dependency lock/package output, explicit generated
+  artifacts, credential-like additions, file modes, and upstream state.
+
+## Boundaries
+
+- No live OpenAI, Pinecone, DynamoDB, AWS, Twilio, API Gateway, or deployment
+  operation is required or claimed.
+- Query-only generation after malformed retrieval remains existing behavior.

--- a/docs/plans/2026-06-16-retrieval-response-accessor.md
+++ b/docs/plans/2026-06-16-retrieval-response-accessor.md
@@ -1,7 +1,7 @@
 ---
 title: Retrieval Response Accessor Safety
 date: 2026-06-16
-status: planned
+status: completed
 execution: code
 ---
 
@@ -45,3 +45,35 @@ and the behavior can be proved offline without credentials or live services.
 - No live OpenAI, Pinecone, DynamoDB, AWS, Twilio, API Gateway, or deployment
   operation is required or claimed.
 - Query-only generation after malformed retrieval remains existing behavior.
+
+## Work Completed
+
+- Verified mapping accessors are callable before invocation and otherwise used
+  safe object attribute lookup.
+- Normalized mapping and attribute accessor exceptions to no retrieval matches.
+- Preserved mapping/object list and tuple compatibility and query-only answer
+  generation.
+- Added focused runtime regressions, mutation-sensitive static contracts, and
+  project guidance for the accessor boundary.
+
+## Verification Completed
+
+- Focused accessor tests and the complete API suite passed with 50 tests.
+- All four Make gates passed: `make check`, `make lint`, `make test`, and
+  `make build`.
+- The external-directory Make gate passed through the absolute Makefile path.
+- Six isolated mutations were rejected: unconditional mapping access, propagated
+  accessor exceptions, discarded safe attributes, removed focused tests,
+  reopened plan status, and removed verification evidence.
+- Compound Engineering review found no actionable findings or testing gaps;
+  browser validation was not applicable to this backend-only change.
+- Dependency lock, binary package policy, extension rendering, Python compile,
+  diff, explicit artifact cleanup, credential, conflict-marker, file-mode, and
+  upstream audits passed.
+- Both canonical implementation-head checks passed at
+  `ad593c9194285ea4a839ca046b31c1dc91427948`: push run 27646936359 and
+  pull-request run 27646948344. PR #31 was OPEN and MERGEABLE with all six
+  required body sections, and code-scanning, Dependabot, and secret-scanning
+  queries returned zero open alerts.
+- No live OpenAI, Pinecone, DynamoDB, AWS, Twilio, API Gateway, or deployment
+  operation was executed.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -49,6 +49,7 @@ LOCATION_INDEPENDENT_MAKE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-location-indepen
 DEPENDENCY_LOCK_PLAN="$ROOT_DIR/docs/plans/2026-06-15-hashed-dependency-lock.md"
 DEPENDENCY_LOCK_CHECK="$ROOT_DIR/scripts/check-dependency-lock.py"
 BINARY_ARTIFACT_PLAN="$ROOT_DIR/docs/plans/2026-06-15-binary-only-dependency-artifacts.md"
+RETRIEVAL_MATCHES_PLAN="$ROOT_DIR/docs/plans/2026-06-16-retrieval-matches-container.md"
 
 require_file() {
   path=$1
@@ -104,6 +105,7 @@ for path in \
   "docs/plans/2026-06-13-location-independent-make.md" \
   "docs/plans/2026-06-15-hashed-dependency-lock.md" \
   "docs/plans/2026-06-15-binary-only-dependency-artifacts.md" \
+  "docs/plans/2026-06-16-retrieval-matches-container.md" \
   "scripts/check-dependency-lock.py" \
   "scripts/check-extension-rendering.sh" \
   "scripts/verify-chalice-package.sh" \
@@ -342,9 +344,19 @@ if ! grep -Fq "def metadata_text_and_url(item)" "$APP" ||
   ! grep -Fq "isinstance(text, str)" "$APP" ||
   ! grep -Fq "MAX_RETRIEVAL_CONTEXT_LENGTH = 4000" "$APP" ||
   ! grep -Fq "context[:MAX_RETRIEVAL_CONTEXT_LENGTH]" "$APP" ||
-  ! grep -Fq "res.get('matches', [])" "$APP" ||
+  ! grep -Fq "matches = retrieval_matches(res)" "$APP" ||
   ! grep -Fq "metadata_text_and_url(item)" "$APP"; then
   printf '%s\n' "Retrieval metadata must be validated before answer generation." >&2
+  exit 1
+fi
+
+if ! grep -Fq "def retrieval_matches(response)" "$APP" ||
+  ! grep -Fq "isinstance(matches, (list, tuple))" "$APP" ||
+  ! grep -Fq "matches = retrieval_matches(res)" "$APP" ||
+  ! grep -Fq "test_make_query_ignores_malformed_matches_containers" "$TEST_APP_AUTH" ||
+  ! grep -Fq "test_retrieval_matches_accepts_list_and_tuple" "$TEST_APP_AUTH" ||
+  ! grep -Fq 'malformed_matches = (None, "matches", 1, {"metadata": {}})' "$TEST_APP_AUTH"; then
+  printf '%s\n' "Retrieval matches containers must be normalized before metadata iteration." >&2
   exit 1
 fi
 
@@ -903,6 +915,44 @@ if ! grep -Fq "binary wheels only" "$README" ||
   printf '%s\n' "Project guidance must document binary-only dependency resolution." >&2
   exit 1
 fi
+
+if ! grep -Fq "Malformed retrieval matches containers" "$README" ||
+  ! grep -Fq "Malformed retrieval matches containers" "$ROOT_DIR/SECURITY.md" ||
+  ! grep -Fq "Malformed retrieval matches containers" "$VISION" ||
+  ! grep -Fq "Malformed retrieval matches containers" "$ROOT_DIR/AGENTS.md" ||
+  ! grep -Fq "Normalized malformed retrieval matches containers" "$CHANGES"; then
+  printf '%s\n' "Project guidance must document retrieval matches-container normalization." >&2
+  exit 1
+fi
+
+python3 - "$RETRIEVAL_MATCHES_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text(encoding="utf-8")
+statuses = re.findall(r"^status: .+$", plan, flags=re.MULTILINE)
+verification = plan.split("## Verification Completed\n", 1)[-1]
+required = (
+    "focused retrieval tests and complete API suite passed",
+    "All four Make gates passed",
+    "external-directory Make gate passed",
+    "container-guard mutation failed",
+    "mapping-acceptance mutation failed",
+    "focused-test contract mutation failed",
+    "plan-status mutation failed",
+    "plan-evidence mutation failed",
+)
+if (
+    statuses != ["status: completed"]
+    or "## Verification Completed\n" not in plan
+    or any(item not in verification for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run|not yet)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Retrieval matches-container plan must record completed verification."
+    )
+PY
 PYTHONPATH="$ROOT_DIR/api" python -m unittest discover -s "$ROOT_DIR/api/tests"
 python -m compileall -q "$ROOT_DIR/api/app.py" "$ROOT_DIR/api/chalicelib" "$ROOT_DIR/api/tests"
 "$EXTENSION_RENDERING_CHECK"

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -994,6 +994,38 @@ if (
         "Retrieval matches-container plan must record completed verification."
     )
 PY
+
+python3 - "$RETRIEVAL_ACCESSOR_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text(encoding="utf-8")
+statuses = re.findall(r"^status: .+$", plan, flags=re.MULTILINE)
+verification = plan.split("## Verification Completed\n", 1)[-1]
+normalized = " ".join(verification.split())
+required = (
+    "complete API suite passed with 50 tests",
+    "All four Make gates passed",
+    "external-directory Make gate passed",
+    "Six isolated mutations were rejected",
+    "no actionable findings or testing gaps",
+    "Both canonical implementation-head checks passed",
+    "push run 27646936359",
+    "pull-request run 27646948344",
+    "zero open alerts",
+    "No live OpenAI, Pinecone, DynamoDB, AWS, Twilio, API Gateway, or deployment operation was executed",
+)
+if (
+    statuses != ["status: completed"]
+    or "## Verification Completed\n" not in plan
+    or any(item not in normalized for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run|not yet)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Retrieval response accessor plan must record completed verification."
+    )
+PY
 PYTHONPATH="$ROOT_DIR/api" python -m unittest discover -s "$ROOT_DIR/api/tests"
 python -m compileall -q "$ROOT_DIR/api/app.py" "$ROOT_DIR/api/chalicelib" "$ROOT_DIR/api/tests"
 "$EXTENSION_RENDERING_CHECK"

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -50,6 +50,7 @@ DEPENDENCY_LOCK_PLAN="$ROOT_DIR/docs/plans/2026-06-15-hashed-dependency-lock.md"
 DEPENDENCY_LOCK_CHECK="$ROOT_DIR/scripts/check-dependency-lock.py"
 BINARY_ARTIFACT_PLAN="$ROOT_DIR/docs/plans/2026-06-15-binary-only-dependency-artifacts.md"
 RETRIEVAL_MATCHES_PLAN="$ROOT_DIR/docs/plans/2026-06-16-retrieval-matches-container.md"
+RETRIEVAL_ACCESSOR_PLAN="$ROOT_DIR/docs/plans/2026-06-16-retrieval-response-accessor.md"
 
 require_file() {
   path=$1
@@ -106,6 +107,7 @@ for path in \
   "docs/plans/2026-06-15-hashed-dependency-lock.md" \
   "docs/plans/2026-06-15-binary-only-dependency-artifacts.md" \
   "docs/plans/2026-06-16-retrieval-matches-container.md" \
+  "docs/plans/2026-06-16-retrieval-response-accessor.md" \
   "scripts/check-dependency-lock.py" \
   "scripts/check-extension-rendering.sh" \
   "scripts/verify-chalice-package.sh" \
@@ -359,6 +361,36 @@ if ! grep -Fq "def retrieval_matches(response)" "$APP" ||
   printf '%s\n' "Retrieval matches containers must be normalized before metadata iteration." >&2
   exit 1
 fi
+
+python3 - "$APP" "$TEST_APP_AUTH" <<'PY'
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1]).read_text(encoding="utf-8")
+tests = Path(sys.argv[2]).read_text(encoding="utf-8")
+helper = source[source.index("def retrieval_matches(response)"):source.index("@app.route('/public/")]
+required_source = (
+    "get_matches = getattr(response, 'get', None)",
+    "if callable(get_matches):",
+    "matches = get_matches('matches', [])",
+    "matches = getattr(response, 'matches', [])",
+    "except Exception:",
+    "return ()",
+)
+required_tests = (
+    "test_retrieval_matches_handles_unsupported_accessors",
+    "test_make_query_uses_query_only_prompt_after_accessor_failure",
+    "NonCallableGetResponse",
+    "RaisingGetResponse",
+    "RaisingMatchesResponse",
+)
+if any(contract not in helper for contract in required_source):
+    raise SystemExit("Retrieval response access must fail safely before container validation.")
+if "hasattr(response, 'get')" in helper:
+    raise SystemExit("Retrieval response access must not call an unverified get attribute.")
+if any(contract not in tests for contract in required_tests):
+    raise SystemExit("Retrieval response accessor regressions must remain registered.")
+PY
 
 if ! grep -Fq 'RETRIEVAL_CONTEXT_SEPARATOR = "\n\n---\n\n"' "$APP" ||
   ! grep -Fq "remaining_context_length = MAX_RETRIEVAL_CONTEXT_LENGTH" "$APP" ||
@@ -922,6 +954,15 @@ if ! grep -Fq "Malformed retrieval matches containers" "$README" ||
   ! grep -Fq "Malformed retrieval matches containers" "$ROOT_DIR/AGENTS.md" ||
   ! grep -Fq "Normalized malformed retrieval matches containers" "$CHANGES"; then
   printf '%s\n' "Project guidance must document retrieval matches-container normalization." >&2
+  exit 1
+fi
+
+if ! grep -Fq "Unusable retrieval response accessors normalize to no matches" "$README" ||
+  ! grep -Fq "Unusable retrieval response accessors must normalize to no matches" "$ROOT_DIR/SECURITY.md" ||
+  ! grep -Fq "Unusable retrieval response accessors normalize to no matches" "$VISION" ||
+  ! grep -Fq "Unusable retrieval response accessors must normalize to no matches" "$ROOT_DIR/AGENTS.md" ||
+  ! grep -Fq "Normalized non-callable or failing retrieval response accessors" "$CHANGES"; then
+  printf '%s\n' "Project guidance must document retrieval response accessor normalization." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Pinecone response wrappers with unusable accessors now fall back to query-only answer generation instead of turning an otherwise recoverable retrieval miss into an API error.

## Baseline

The existing matches-container guard ran only after `response.get(...)` or attribute access. A non-callable `get`, a mapping accessor that raised, or a failing `matches` property escaped before normalization.

## Improvements

- verify the mapping accessor is callable before invoking it
- preserve safe object-attribute response compatibility when `get` is absent or non-callable
- normalize mapping and attribute accessor failures to no matches
- protect query-only generation with focused runtime and mutation-sensitive static tests

## Validation

- all 50 offline API tests passed
- `make check`, `make lint`, `make test`, and `make build` passed
- the absolute-Makefile check passed from `/tmp`
- four source/test mutations were rejected before completed-plan verification
- dependency lock, package, extension rendering, artifact, credential, mode, and upstream audits passed

## Risk

Accessor exceptions intentionally become an empty retrieval set, preserving the existing query-only model call. No live OpenAI, Pinecone, DynamoDB, AWS, Twilio, API Gateway, or deployment operation was executed. This PR is stacked on open PR #30.

## Follow-Ups

Preserve stack order by merging PR #30 before this PR. Neither pull request is merged or closed by this workflow.


---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.4-000000)
