### PR TITLE
Tolerate retrieval metadata accessor failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,9 @@
   per-item metadata validation and answer generation.
 - Unusable retrieval response accessors must normalize to no matches before
   container validation; preserve callable mapping and object attribute forms.
+- Unusable retrieval metadata accessors must normalize to missing metadata
+  before per-item shape validation; preserve callable mapping and object
+  attribute forms.
 - Keep the classification weight schema limited to numeric `with_code`, `minimal_code`, and `no_code` values.
 - Chalice installs deployable dependencies from `api/requirements.txt`; do not
   commit generated `api/vendor/` content, Python bytecode, caches, or package

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,8 @@
 - Keep DynamoDB response caching best-effort: cache read failures must continue to fresh retrieval, and cache write failures must not discard a generated response.
 - Malformed retrieval matches containers must normalize to no matches before
   per-item metadata validation and answer generation.
+- Unusable retrieval response accessors must normalize to no matches before
+  container validation; preserve callable mapping and object attribute forms.
 - Keep the classification weight schema limited to numeric `with_code`, `minimal_code`, and `no_code` values.
 - Chalice installs deployable dependencies from `api/requirements.txt`; do not
   commit generated `api/vendor/` content, Python bytecode, caches, or package

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-16
 
+- Normalized non-callable or failing retrieval response accessors to no matches
+  while preserving mapping and object response compatibility.
 - Normalized malformed retrieval matches containers to an empty collection
   before per-item metadata validation.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-17
+
+- Normalized non-callable or failing retrieval metadata accessors to missing
+  metadata while preserving mapping and object match compatibility.
+
 ## 2026-06-16
 
 - Normalized non-callable or failing retrieval response accessors to no matches

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   metadata iteration, preserving query-only answer generation.
 - Unusable retrieval response accessors normalize to no matches, while
   callable mapping access and safe object attributes remain supported.
+- Unusable retrieval metadata accessors normalize to missing metadata, while
+  callable mapping access and safe object attributes remain supported.
 - Keep the retrieval context length guard in place so oversized Pinecone
   metadata cannot expand generated-answer prompts without bound.
 - Keep the total retrieval context budget shared across all matches, including

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   metadata is skipped before answer generation.
 - Malformed retrieval matches containers normalize to no matches before
   metadata iteration, preserving query-only answer generation.
+- Unusable retrieval response accessors normalize to no matches, while
+  callable mapping access and safe object attributes remain supported.
 - Keep the retrieval context length guard in place so oversized Pinecone
   metadata cannot expand generated-answer prompts without bound.
 - Keep the total retrieval context budget shared across all matches, including

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,8 @@ prompts. Links for excluded context should not be returned as supporting
 sources.
 Malformed retrieval matches containers must normalize to no matches before
 provider-controlled values are iterated.
+Unusable retrieval response accessors must normalize to no matches before
+provider-controlled containers are inspected.
 Generated-answer cache entries should carry a bounded `expires_at` lifetime;
 enable DynamoDB TTL on that attribute so stale query data is physically removed.
 Cache partition keys use a namespaced SHA-256 digest rather than raw user

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,6 +50,8 @@ Malformed retrieval matches containers must normalize to no matches before
 provider-controlled values are iterated.
 Unusable retrieval response accessors must normalize to no matches before
 provider-controlled containers are inspected.
+Unusable retrieval metadata accessors must normalize to missing metadata before
+provider-controlled match metadata is inspected.
 Generated-answer cache entries should carry a bounded `expires_at` lifetime;
 enable DynamoDB TTL on that attribute so stale query data is physically removed.
 Cache partition keys use a namespaced SHA-256 digest rather than raw user

--- a/VISION.md
+++ b/VISION.md
@@ -29,6 +29,8 @@ Priority:
   metadata iteration and query-only answer generation
 - Unusable retrieval response accessors normalize to no matches while mapping
   and object response compatibility remains intact
+- Unusable retrieval metadata accessors normalize to missing metadata while
+  mapping and object match compatibility remains intact
 - Preserve the retrieval context length guard before prompt assembly
 - Preserve one total retrieval context budget across all matches and separators
 - Preserve one-day cache expiration and the DynamoDB `expires_at` TTL attribute

--- a/VISION.md
+++ b/VISION.md
@@ -27,6 +27,8 @@ Priority:
 - Preserve the retrieval metadata guard before answer generation
 - Malformed retrieval matches containers normalize to no matches before
   metadata iteration and query-only answer generation
+- Unusable retrieval response accessors normalize to no matches while mapping
+  and object response compatibility remains intact
 - Preserve the retrieval context length guard before prompt assembly
 - Preserve one total retrieval context budget across all matches and separators
 - Preserve one-day cache expiration and the DynamoDB `expires_at` TTL attribute

--- a/api/app.py
+++ b/api/app.py
@@ -106,11 +106,22 @@ def filter_twilio_doc_urls(urls):
     return sorted(filtered_urls)
 
 
+def retrieval_metadata(item):
+    """Return match metadata without propagating provider accessor failures."""
+    try:
+        if isinstance(item, dict):
+            get_metadata = getattr(item, 'get', None)
+            if not callable(get_metadata):
+                return None
+            return get_metadata('metadata')
+        return getattr(item, 'metadata', None)
+    except Exception:
+        return None
+
+
 def metadata_text_and_url(item):
     """Return usable retrieval context and URL metadata from a Pinecone match."""
-    metadata = item.get('metadata') if isinstance(item, dict) else getattr(
-        item, 'metadata', None
-    )
+    metadata = retrieval_metadata(item)
     if not isinstance(metadata, dict):
         return None, None
 

--- a/api/app.py
+++ b/api/app.py
@@ -133,9 +133,15 @@ def metadata_text_and_url(item):
 
 def retrieval_matches(response):
     """Return Pinecone matches only from a supported collection shape."""
-    matches = response.get('matches', []) if hasattr(response, 'get') else getattr(
-        response, 'matches', []
-    )
+    try:
+        get_matches = getattr(response, 'get', None)
+        if callable(get_matches):
+            matches = get_matches('matches', [])
+        else:
+            matches = getattr(response, 'matches', [])
+    except Exception:
+        return ()
+
     if not isinstance(matches, (list, tuple)):
         return ()
     return matches

--- a/api/tests/test_app_auth.py
+++ b/api/tests/test_app_auth.py
@@ -459,6 +459,54 @@ class AppAuthTests(unittest.TestCase):
             "Response", (), {"matches": (match,)}
         )()))
 
+    def test_retrieval_matches_handles_unsupported_accessors(self):
+        match = {"metadata": {"text": "context"}}
+
+        class NonCallableGetResponse:
+            get = None
+            matches = [match]
+
+        class RaisingGetResponse:
+            def get(self, key, default):
+                raise RuntimeError("provider mapping failure")
+
+        class RaisingMatchesResponse:
+            @property
+            def matches(self):
+                raise RuntimeError("provider attribute failure")
+
+        self.assertEqual(
+            [match],
+            self.app_module.retrieval_matches(NonCallableGetResponse()),
+        )
+        self.assertEqual((), self.app_module.retrieval_matches(RaisingGetResponse()))
+        self.assertEqual(
+            (),
+            self.app_module.retrieval_matches(RaisingMatchesResponse()),
+        )
+
+    def test_make_query_uses_query_only_prompt_after_accessor_failure(self):
+        class RaisingGetResponse:
+            def get(self, key, default):
+                raise RuntimeError("provider mapping failure")
+
+        class FakeIndex:
+            def query(self, *args, **kwargs):
+                return RaisingGetResponse()
+
+        with patch.object(self.app_module, "get_embeddings", return_value=[0.1]):
+            with patch.object(self.app_module, "get_index", return_value=FakeIndex()):
+                with patch.object(
+                    self.app_module,
+                    "generate_response",
+                    return_value="answer",
+                ) as generate_response:
+                    response, links = self.app_module.make_query("How?")
+
+        self.assertEqual(response, "answer")
+        self.assertEqual(links, [])
+        generate_response.assert_called_once_with("\n\n-----\n\nHow?")
+
     def test_make_query_truncates_overlong_metadata_text(self):
         long_context = "x" * (self.app_module.MAX_RETRIEVAL_CONTEXT_LENGTH + 25)
 

--- a/api/tests/test_app_auth.py
+++ b/api/tests/test_app_auth.py
@@ -423,6 +423,78 @@ class AppAuthTests(unittest.TestCase):
             "context a\n\n---\n\ncontext b\n\n-----\n\nHow?",
         )
 
+    def test_retrieval_metadata_handles_unsupported_accessors(self):
+        metadata = {"text": "context"}
+
+        class ObjectMatch:
+            def __init__(self):
+                self.metadata = metadata
+
+        class NonCallableGetMatch(dict):
+            get = None
+
+        class RaisingGetMatch(dict):
+            def get(self, key):
+                raise RuntimeError("provider mapping failure")
+
+        class RaisingMetadataMatch:
+            get = None
+
+            @property
+            def metadata(self):
+                raise RuntimeError("provider attribute failure")
+
+        self.assertEqual(metadata, self.app_module.retrieval_metadata({
+            "metadata": metadata,
+        }))
+        self.assertEqual(
+            metadata,
+            self.app_module.retrieval_metadata(ObjectMatch()),
+        )
+        self.assertIsNone(
+            self.app_module.retrieval_metadata(NonCallableGetMatch()),
+        )
+        self.assertIsNone(
+            self.app_module.retrieval_metadata(RaisingGetMatch()),
+        )
+        self.assertIsNone(
+            self.app_module.retrieval_metadata(RaisingMetadataMatch()),
+        )
+
+    def test_make_query_skips_metadata_accessor_failures(self):
+        class RaisingGetMatch(dict):
+            def get(self, key):
+                raise RuntimeError("provider mapping failure")
+
+        class FakeIndex:
+            def query(self, *args, **kwargs):
+                return {
+                    "matches": [
+                        RaisingGetMatch(),
+                        {
+                            "metadata": {
+                                "text": "usable context",
+                                "url": "https://www.twilio.com/docs/usable",
+                            }
+                        },
+                    ]
+                }
+
+        with patch.object(self.app_module, "get_embeddings", return_value=[0.1]):
+            with patch.object(self.app_module, "get_index", return_value=FakeIndex()):
+                with patch.object(
+                    self.app_module,
+                    "generate_response",
+                    return_value="answer",
+                ) as generate_response:
+                    response, links = self.app_module.make_query("How?")
+
+        self.assertEqual(response, "answer")
+        self.assertEqual(links, ["https://www.twilio.com/docs/usable"])
+        generate_response.assert_called_once_with(
+            "usable context\n\n-----\n\nHow?"
+        )
+
     def test_make_query_ignores_malformed_matches_containers(self):
         malformed_matches = (None, "matches", 1, {"metadata": {}})
 

--- a/docs/plans/2026-06-16-retrieval-response-accessor.md
+++ b/docs/plans/2026-06-16-retrieval-response-accessor.md
@@ -1,0 +1,47 @@
+---
+title: Retrieval Response Accessor Safety
+date: 2026-06-16
+status: planned
+execution: code
+---
+
+## Context
+
+`retrieval_matches()` normalizes malformed `matches` containers, but it first
+uses `hasattr(response, 'get')` and then calls `response.get(...)`
+unconditionally. A provider wrapper with a non-callable `get` attribute, or an
+accessor that raises, fails before the container guard and turns the intended
+query-only fallback into an API error.
+
+## Priority
+
+This is the remaining deterministic boundary immediately before the completed
+matches-container validation. The response is controlled by an external SDK,
+and the behavior can be proved offline without credentials or live services.
+
+## Plan
+
+1. Extract `matches` only through a callable mapping accessor or safe attribute
+   lookup.
+2. Normalize accessor failures and unsupported response shapes to no matches.
+3. Preserve mapping/object list and tuple compatibility, context budgets,
+   citation filtering, and query-only generation.
+4. Add focused runtime tests and mutation-sensitive baseline contracts.
+5. Record actual focused, full-gate, external-directory, review, audit, and
+   hosted verification evidence.
+
+## Verification
+
+- Run focused API tests and the complete `make check`, `make lint`, `make test`,
+  and `make build` gates with explicit timeouts.
+- Run the absolute-Makefile check from an external directory.
+- Reject mutations that restore unconditional `.get`, propagate accessor
+  failures, remove focused tests, or reopen completed plan evidence.
+- Audit exact diff, dependency lock/package output, explicit generated
+  artifacts, credential-like additions, file modes, and upstream state.
+
+## Boundaries
+
+- No live OpenAI, Pinecone, DynamoDB, AWS, Twilio, API Gateway, or deployment
+  operation is required or claimed.
+- Query-only generation after malformed retrieval remains existing behavior.

--- a/docs/plans/2026-06-16-retrieval-response-accessor.md
+++ b/docs/plans/2026-06-16-retrieval-response-accessor.md
@@ -1,7 +1,7 @@
 ---
 title: Retrieval Response Accessor Safety
 date: 2026-06-16
-status: planned
+status: completed
 execution: code
 ---
 
@@ -45,3 +45,35 @@ and the behavior can be proved offline without credentials or live services.
 - No live OpenAI, Pinecone, DynamoDB, AWS, Twilio, API Gateway, or deployment
   operation is required or claimed.
 - Query-only generation after malformed retrieval remains existing behavior.
+
+## Work Completed
+
+- Verified mapping accessors are callable before invocation and otherwise used
+  safe object attribute lookup.
+- Normalized mapping and attribute accessor exceptions to no retrieval matches.
+- Preserved mapping/object list and tuple compatibility and query-only answer
+  generation.
+- Added focused runtime regressions, mutation-sensitive static contracts, and
+  project guidance for the accessor boundary.
+
+## Verification Completed
+
+- Focused accessor tests and the complete API suite passed with 50 tests.
+- All four Make gates passed: `make check`, `make lint`, `make test`, and
+  `make build`.
+- The external-directory Make gate passed through the absolute Makefile path.
+- Six isolated mutations were rejected: unconditional mapping access, propagated
+  accessor exceptions, discarded safe attributes, removed focused tests,
+  reopened plan status, and removed verification evidence.
+- Compound Engineering review found no actionable findings or testing gaps;
+  browser validation was not applicable to this backend-only change.
+- Dependency lock, binary package policy, extension rendering, Python compile,
+  diff, explicit artifact cleanup, credential, conflict-marker, file-mode, and
+  upstream audits passed.
+- Both canonical implementation-head checks passed at
+  `ad593c9194285ea4a839ca046b31c1dc91427948`: push run 27646936359 and
+  pull-request run 27646948344. PR #31 was OPEN and MERGEABLE with all six
+  required body sections, and code-scanning, Dependabot, and secret-scanning
+  queries returned zero open alerts.
+- No live OpenAI, Pinecone, DynamoDB, AWS, Twilio, API Gateway, or deployment
+  operation was executed.

--- a/docs/plans/2026-06-17-retrieval-metadata-accessor.md
+++ b/docs/plans/2026-06-17-retrieval-metadata-accessor.md
@@ -1,7 +1,7 @@
 ---
 title: Retrieval Metadata Accessor Safety
 date: 2026-06-17
-status: active
+status: completed
 execution: code
 ---
 
@@ -60,8 +60,33 @@ live OpenAI, Pinecone, DynamoDB, AWS, Twilio, or deployment calls.
 
 ## Work Completed
 
-Pending implementation.
+- Added `retrieval_metadata` to verify dictionary accessors before invocation,
+  normalize accessor exceptions to missing metadata, and preserve object-style
+  metadata attributes.
+- Kept the existing metadata shape, text, URL, context, and citation policies
+  unchanged after successful access.
+- Added focused helper and mixed-match request regressions, mutation-sensitive
+  baseline contracts, and repository guidance for the provider boundary.
 
 ## Verification Completed
 
-Pending implementation and validation.
+- Focused metadata accessor regressions and the complete API suite passed with
+  52 tests.
+- All four Make gates passed: `make check`, `make lint`, `make test`, and
+  `make build`.
+- The external-directory Make gate passed through the absolute Makefile path.
+- Six isolated mutations were rejected: unconditional mapping access, narrowed
+  exception containment, non-callable invocation, object dispatch regression,
+  focused-test removal, and guidance removal.
+- Compound Engineering review resolved one object-compatibility finding and
+  ended with no actionable findings.
+- Dependency lock, extension rendering, Python compilation, diff, explicit
+  artifact cleanup, credential-pattern, conflict-marker, file-mode,
+  clean-worktree, and exact-upstream audits passed.
+- Both canonical implementation-head checks passed at
+  `fa00a133c7149d6e3b80bb93a64fe5638bfaef14`: push run 27664285855 and
+  pull-request run 27664290314. PR #32 was OPEN, CLEAN, and MERGEABLE, and
+  code-scanning, Dependabot, and secret-scanning queries returned zero open
+  alerts.
+- No live OpenAI, Pinecone, DynamoDB, AWS, Twilio, API Gateway, or deployment
+  operation was executed.

--- a/docs/plans/2026-06-17-retrieval-metadata-accessor.md
+++ b/docs/plans/2026-06-17-retrieval-metadata-accessor.md
@@ -1,0 +1,67 @@
+---
+title: Retrieval Metadata Accessor Safety
+date: 2026-06-17
+status: active
+execution: code
+---
+
+## Context
+
+Top-level Pinecone response access is normalized before match iteration, but
+`metadata_text_and_url` still invokes a match mapping's `get` method or reads
+its `metadata` attribute without containing provider accessor failures. A
+single malformed match can therefore abort an authenticated `/ask` request
+instead of being skipped like other unusable retrieval metadata.
+
+## Priority
+
+This is the highest-value remaining deterministic retrieval boundary because
+the value is controlled by an external provider, bypasses the existing
+per-match shape guard, and can be fixed and verified without credentials or
+live OpenAI, Pinecone, DynamoDB, AWS, Twilio, or deployment calls.
+
+## Plan
+
+1. Add a small metadata accessor helper that calls only callable mapping
+   accessors, preserves safe object attribute fallback, and normalizes accessor
+   exceptions to missing metadata.
+2. Keep the existing dictionary, text, URL, and context-budget validation
+   unchanged after metadata access succeeds.
+3. Add focused runtime regressions and mutation-sensitive static contracts for
+   non-callable, raising mapping, and raising attribute accessors.
+4. Update repository guidance and the changelog for the provider boundary.
+5. Run focused and complete tests, all Make gates, the external-directory gate,
+   isolated mutations, structured review, and final artifact/secret/diff
+   audits.
+6. Push the exact branch, open a stacked pull request against the retrieval
+   response accessor branch, and take one bounded hosted/security snapshot.
+
+## Non-Goals
+
+- Calling live OpenAI, Pinecone, DynamoDB, AWS, Twilio, API Gateway, or
+  deployment services.
+- Changing top-level matches-container or response-accessor behavior.
+- Changing accepted metadata, URL filtering, prompt budgets, cache behavior,
+  dependency locks, binary-package policy, or deployment packaging.
+- Migrating legacy OpenAI or Pinecone client APIs.
+
+## Verification Required
+
+- Focused metadata accessor tests and the complete API suite pass.
+- `make check`, `make lint`, `make test`, and `make build` pass from the
+  repository, and the absolute Makefile check passes externally.
+- Mutations restoring unconditional mapping access, propagating accessor
+  failures, accepting non-callable accessors, removing focused coverage, or
+  staling plan evidence fail.
+- Compound Engineering review has no unresolved actionable findings.
+- Final intended paths pass compile, dependency-lock, extension-rendering,
+  whitespace, artifact, credential, conflict-marker, file-mode, and
+  upstream-alignment audits.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and validation.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -108,6 +108,7 @@ for path in \
   "docs/plans/2026-06-15-binary-only-dependency-artifacts.md" \
   "docs/plans/2026-06-16-retrieval-matches-container.md" \
   "docs/plans/2026-06-16-retrieval-response-accessor.md" \
+  "docs/plans/2026-06-17-retrieval-metadata-accessor.md" \
   "scripts/check-dependency-lock.py" \
   "scripts/check-extension-rendering.sh" \
   "scripts/verify-chalice-package.sh" \
@@ -342,6 +343,7 @@ if ! grep -Fq "def is_twilio_doc_url(url)" "$APP" ||
 fi
 
 if ! grep -Fq "def metadata_text_and_url(item)" "$APP" ||
+  ! grep -Fq "metadata = retrieval_metadata(item)" "$APP" ||
   ! grep -Fq "isinstance(metadata, dict)" "$APP" ||
   ! grep -Fq "isinstance(text, str)" "$APP" ||
   ! grep -Fq "MAX_RETRIEVAL_CONTEXT_LENGTH = 4000" "$APP" ||
@@ -351,6 +353,40 @@ if ! grep -Fq "def metadata_text_and_url(item)" "$APP" ||
   printf '%s\n' "Retrieval metadata must be validated before answer generation." >&2
   exit 1
 fi
+
+python3 - "$APP" "$TEST_APP_AUTH" <<'PY'
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1]).read_text(encoding="utf-8")
+tests = Path(sys.argv[2]).read_text(encoding="utf-8")
+helper = source[
+    source.index("def retrieval_metadata(item)"):
+    source.index("def metadata_text_and_url(item)")
+]
+required_source = (
+    "if isinstance(item, dict):",
+    "get_metadata = getattr(item, 'get', None)",
+    "if not callable(get_metadata):",
+    "return None",
+    "return get_metadata('metadata')",
+    "return getattr(item, 'metadata', None)",
+    "except Exception:",
+)
+required_tests = (
+    "test_retrieval_metadata_handles_unsupported_accessors",
+    "test_make_query_skips_metadata_accessor_failures",
+    "NonCallableGetMatch",
+    "RaisingGetMatch",
+    "RaisingMetadataMatch",
+)
+if any(contract not in helper for contract in required_source):
+    raise SystemExit("Retrieval metadata access must fail safely before shape validation.")
+if "item.get('metadata') if isinstance(item, dict)" in source:
+    raise SystemExit("Retrieval metadata access must not call an unverified get attribute.")
+if any(contract not in tests for contract in required_tests):
+    raise SystemExit("Retrieval metadata accessor regressions must remain registered.")
+PY
 
 if ! grep -Fq "def retrieval_matches(response)" "$APP" ||
   ! grep -Fq "isinstance(matches, (list, tuple))" "$APP" ||
@@ -966,6 +1002,15 @@ if ! grep -Fq "Unusable retrieval response accessors normalize to no matches" "$
   exit 1
 fi
 
+if ! grep -Fq "Unusable retrieval metadata accessors normalize to missing metadata" "$README" ||
+  ! grep -Fq "Unusable retrieval metadata accessors must normalize to missing metadata" "$ROOT_DIR/SECURITY.md" ||
+  ! grep -Fq "Unusable retrieval metadata accessors normalize to missing metadata" "$VISION" ||
+  ! grep -Fq "Unusable retrieval metadata accessors must normalize to missing metadata" "$ROOT_DIR/AGENTS.md" ||
+  ! grep -Fq "Normalized non-callable or failing retrieval metadata accessors" "$CHANGES"; then
+  printf '%s\n' "Project guidance must document retrieval metadata accessor normalization." >&2
+  exit 1
+fi
+
 python3 - "$RETRIEVAL_MATCHES_PLAN" <<'PY'
 import re
 import sys
@@ -1026,6 +1071,7 @@ if (
         "Retrieval response accessor plan must record completed verification."
     )
 PY
+
 PYTHONPATH="$ROOT_DIR/api" python -m unittest discover -s "$ROOT_DIR/api/tests"
 python -m compileall -q "$ROOT_DIR/api/app.py" "$ROOT_DIR/api/chalicelib" "$ROOT_DIR/api/tests"
 "$EXTENSION_RENDERING_CHECK"

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -51,6 +51,7 @@ DEPENDENCY_LOCK_CHECK="$ROOT_DIR/scripts/check-dependency-lock.py"
 BINARY_ARTIFACT_PLAN="$ROOT_DIR/docs/plans/2026-06-15-binary-only-dependency-artifacts.md"
 RETRIEVAL_MATCHES_PLAN="$ROOT_DIR/docs/plans/2026-06-16-retrieval-matches-container.md"
 RETRIEVAL_ACCESSOR_PLAN="$ROOT_DIR/docs/plans/2026-06-16-retrieval-response-accessor.md"
+RETRIEVAL_METADATA_ACCESSOR_PLAN="$ROOT_DIR/docs/plans/2026-06-17-retrieval-metadata-accessor.md"
 
 require_file() {
   path=$1
@@ -1069,6 +1070,38 @@ if (
 ):
     raise SystemExit(
         "Retrieval response accessor plan must record completed verification."
+    )
+PY
+
+python3 - "$RETRIEVAL_METADATA_ACCESSOR_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text(encoding="utf-8")
+statuses = re.findall(r"^status: .+$", plan, flags=re.MULTILINE)
+verification = plan.split("## Verification Completed\n", 1)[-1]
+normalized = " ".join(verification.split())
+required = (
+    "complete API suite passed with 52 tests",
+    "All four Make gates passed",
+    "external-directory Make gate passed",
+    "Six isolated mutations were rejected",
+    "no actionable findings",
+    "Both canonical implementation-head checks passed",
+    "push run 27664285855",
+    "pull-request run 27664290314",
+    "zero open alerts",
+    "No live OpenAI, Pinecone, DynamoDB, AWS, Twilio, API Gateway, or deployment operation was executed",
+)
+if (
+    statuses != ["status: completed"]
+    or "## Verification Completed\n" not in plan
+    or any(item not in normalized for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run|not yet)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Retrieval metadata accessor plan must record completed verification."
     )
 PY
 

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -994,6 +994,38 @@ if (
         "Retrieval matches-container plan must record completed verification."
     )
 PY
+
+python3 - "$RETRIEVAL_ACCESSOR_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text(encoding="utf-8")
+statuses = re.findall(r"^status: .+$", plan, flags=re.MULTILINE)
+verification = plan.split("## Verification Completed\n", 1)[-1]
+normalized = " ".join(verification.split())
+required = (
+    "complete API suite passed with 50 tests",
+    "All four Make gates passed",
+    "external-directory Make gate passed",
+    "Six isolated mutations were rejected",
+    "no actionable findings or testing gaps",
+    "Both canonical implementation-head checks passed",
+    "push run 27646936359",
+    "pull-request run 27646948344",
+    "zero open alerts",
+    "No live OpenAI, Pinecone, DynamoDB, AWS, Twilio, API Gateway, or deployment operation was executed",
+)
+if (
+    statuses != ["status: completed"]
+    or "## Verification Completed\n" not in plan
+    or any(item not in normalized for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run|not yet)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Retrieval response accessor plan must record completed verification."
+    )
+PY
 PYTHONPATH="$ROOT_DIR/api" python -m unittest discover -s "$ROOT_DIR/api/tests"
 python -m compileall -q "$ROOT_DIR/api/app.py" "$ROOT_DIR/api/chalicelib" "$ROOT_DIR/api/tests"
 "$EXTENSION_RENDERING_CHECK"

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -50,6 +50,7 @@ DEPENDENCY_LOCK_PLAN="$ROOT_DIR/docs/plans/2026-06-15-hashed-dependency-lock.md"
 DEPENDENCY_LOCK_CHECK="$ROOT_DIR/scripts/check-dependency-lock.py"
 BINARY_ARTIFACT_PLAN="$ROOT_DIR/docs/plans/2026-06-15-binary-only-dependency-artifacts.md"
 RETRIEVAL_MATCHES_PLAN="$ROOT_DIR/docs/plans/2026-06-16-retrieval-matches-container.md"
+RETRIEVAL_ACCESSOR_PLAN="$ROOT_DIR/docs/plans/2026-06-16-retrieval-response-accessor.md"
 
 require_file() {
   path=$1
@@ -106,6 +107,7 @@ for path in \
   "docs/plans/2026-06-15-hashed-dependency-lock.md" \
   "docs/plans/2026-06-15-binary-only-dependency-artifacts.md" \
   "docs/plans/2026-06-16-retrieval-matches-container.md" \
+  "docs/plans/2026-06-16-retrieval-response-accessor.md" \
   "scripts/check-dependency-lock.py" \
   "scripts/check-extension-rendering.sh" \
   "scripts/verify-chalice-package.sh" \
@@ -359,6 +361,36 @@ if ! grep -Fq "def retrieval_matches(response)" "$APP" ||
   printf '%s\n' "Retrieval matches containers must be normalized before metadata iteration." >&2
   exit 1
 fi
+
+python3 - "$APP" "$TEST_APP_AUTH" <<'PY'
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1]).read_text(encoding="utf-8")
+tests = Path(sys.argv[2]).read_text(encoding="utf-8")
+helper = source[source.index("def retrieval_matches(response)"):source.index("@app.route('/public/")]
+required_source = (
+    "get_matches = getattr(response, 'get', None)",
+    "if callable(get_matches):",
+    "matches = get_matches('matches', [])",
+    "matches = getattr(response, 'matches', [])",
+    "except Exception:",
+    "return ()",
+)
+required_tests = (
+    "test_retrieval_matches_handles_unsupported_accessors",
+    "test_make_query_uses_query_only_prompt_after_accessor_failure",
+    "NonCallableGetResponse",
+    "RaisingGetResponse",
+    "RaisingMatchesResponse",
+)
+if any(contract not in helper for contract in required_source):
+    raise SystemExit("Retrieval response access must fail safely before container validation.")
+if "hasattr(response, 'get')" in helper:
+    raise SystemExit("Retrieval response access must not call an unverified get attribute.")
+if any(contract not in tests for contract in required_tests):
+    raise SystemExit("Retrieval response accessor regressions must remain registered.")
+PY
 
 if ! grep -Fq 'RETRIEVAL_CONTEXT_SEPARATOR = "\n\n---\n\n"' "$APP" ||
   ! grep -Fq "remaining_context_length = MAX_RETRIEVAL_CONTEXT_LENGTH" "$APP" ||
@@ -922,6 +954,15 @@ if ! grep -Fq "Malformed retrieval matches containers" "$README" ||
   ! grep -Fq "Malformed retrieval matches containers" "$ROOT_DIR/AGENTS.md" ||
   ! grep -Fq "Normalized malformed retrieval matches containers" "$CHANGES"; then
   printf '%s\n' "Project guidance must document retrieval matches-container normalization." >&2
+  exit 1
+fi
+
+if ! grep -Fq "Unusable retrieval response accessors normalize to no matches" "$README" ||
+  ! grep -Fq "Unusable retrieval response accessors must normalize to no matches" "$ROOT_DIR/SECURITY.md" ||
+  ! grep -Fq "Unusable retrieval response accessors normalize to no matches" "$VISION" ||
+  ! grep -Fq "Unusable retrieval response accessors must normalize to no matches" "$ROOT_DIR/AGENTS.md" ||
+  ! grep -Fq "Normalized non-callable or failing retrieval response accessors" "$CHANGES"; then
+  printf '%s\n' "Project guidance must document retrieval response accessor normalization." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Contain malformed Pinecone match metadata accessors so one provider-controlled item cannot abort an authenticated answer request.

## Baseline

Top-level retrieval response access and matches-container shapes were already normalized, but dictionary match objects still invoked `get('metadata')` without verifying the accessor or containing provider exceptions.

## Improvements

- Validate dictionary metadata accessors before invocation and normalize failures to missing metadata.
- Preserve the existing object-style `.metadata` path for Pinecone SDK match objects.
- Add focused mixed-match regressions and mutation-sensitive static contracts.
- Document the boundary in repository guidance and the maintenance changelog.

## Validation

- Focused metadata accessor regressions passed.
- Complete API suite passed with 52 tests.
- `make check`, `make lint`, `make test`, and `make build` passed.
- The absolute Makefile check passed from `/tmp`.
- Six isolated hostile mutations were rejected.
- Dependency-lock, extension-rendering, compile, diff, explicit artifact, credential-pattern, file-mode, and upstream audits passed.

## Risk

No live OpenAI, Pinecone, DynamoDB, AWS, Twilio, API Gateway, or deployment operation was executed. Malformed matches are skipped while valid later matches remain usable. This PR is stacked on PR #31 and must follow it.

## Follow-Ups

Complete exact-head hosted verification, then add the final run and alert evidence to the plan without merging or closing the stack.
