### PR TITLE
fix: enforce raw query length boundary

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,23 @@
 # Changes
 
+## 2026-06-26T22:48:23Z
+
+- **Priority:** Security and request resource boundaries.
+- **Summary:** Reject overlong raw query strings before trimming whitespace so
+  authenticated callers cannot bypass the documented request-size guard with
+  a tiny normalized query wrapped in excessive padding.
+- **Files:** `api/chalicelib/utils.py`, `api/tests/test_utils.py`,
+  `scripts/check-baseline.sh`, `README.md`, `SECURITY.md`, and `CHANGES.md`.
+- **Tests:** Added a focused failing regression before implementation; Python
+  3.10 `make verify` passes all 64 tests and repository baseline checks.
+- **Findings:** The checked-in extension clients still call authenticated API
+  routes without credentials; resolving that safely requires a separate trust
+  model rather than embedding a shared server secret in public JavaScript;
+  tracked separately as issue #36.
+- **Blockers:** None for this request-boundary fix.
+- **Next action:** Open the focused pull request and require hosted checks on
+  its exact head SHA before merge.
+
 ## 2026-06-18
 
 - Made Chalice package verification forward cancellation signals to its active

--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ The API implementation targets AWS Chalice, while repository settings publish
 the static project content through GitHub Pages. Vercel automatic Git deployments are disabled
 in `vercel.json` because their rewrite targeted the Flask entry point retired
 during the 2023 Chalice migration.
-Request validation rejects missing, non-string, whitespace-only, and over the
-maximum query length values before model or retrieval work starts.
+Request validation rejects missing, non-string, whitespace-only, and over-limit
+values. The maximum query length applies to the raw value before trimming or
+model and retrieval work.
 The retrieval context length guard enforces one separator-aware 4,000-character
 total retrieval context budget across accepted Pinecone matches before
 generated-answer prompt assembly. Links are returned only for included context.
@@ -114,8 +115,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   a stronger API Gateway/JWT authorizer. Public asset routes may remain
   unauthenticated, but public asset routes must stay path-bound to
   `api/chalicelib/public`.
-- Keep request query validation bounded by a maximum query length before routes
-  invoke OpenAI, Pinecone, DynamoDB, or cache helpers.
+- Keep the maximum query length applied to the raw request value before trimming
+  or invoking OpenAI, Pinecone, DynamoDB, or cache helpers.
 - DynamoDB cache entries expire after one day in application reads and include
   an integer `expires_at` epoch attribute for DynamoDB TTL cleanup.
 - Cache reads and writes use a fixed-size SHA-256 identity in the existing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,6 +40,9 @@ Helpful reports include:
 
 For web services, APIs, sockets, or scraping workflows, prioritize reports involving authentication bypass, authorization errors, injection, server-side request forgery, unsafe deserialization, credential leakage, data exposure, or denial-of-service conditions. Use test accounts and minimal proof-of-concept traffic only.
 
+Validate the maximum raw query length before trimming whitespace so padded
+requests cannot bypass the application-level resource boundary.
+
 For AI-generated responses, validate model output schemas before exposing values to callers. The `/classify/builder` response must remain limited to finite numeric `with_code`, `minimal_code`, and `no_code` weights.
 
 Retrieved document context should share one separator-aware total length budget

--- a/VISION.md
+++ b/VISION.md
@@ -39,7 +39,8 @@ Priority:
 - Treat malformed cache payloads as misses and revalidate cached citations
 - Keep cache backend failures from blocking fresh or already generated answers
 - Keep unexpected route failures behind generic 500 errors
-- Keep request validation bounded by a maximum query length before model work
+- Keep the maximum query length applied to raw request values before trimming
+  or model work
 - Keep the classification weight schema explicit and numeric before returning
   model output to callers
 - Keep unauthenticated public asset serving path-bound to checked-in assets
@@ -88,7 +89,7 @@ Contribution rules:
   operational monitoring.
 - Keep unexpected route failures logged server-side while returning generic 500
   errors to callers.
-- Keep the maximum query length guard in request validation.
+- Keep the maximum query length guard before request normalization.
 - Keep the classification weight schema guard on `/classify/builder` responses.
 - Keep public asset routes path-bound to `api/chalicelib/public`.
 - Keep GitHub Actions aligned with the no-live-credentials local gate.

--- a/api/chalicelib/utils.py
+++ b/api/chalicelib/utils.py
@@ -16,11 +16,11 @@ def validate_request_payload(request_json) -> str:
         raise ValueError('Missing "query" key in request body')
     if not isinstance(query, str):
         raise ValueError('Query must be a string')
+    if len(query) > MAX_QUERY_LENGTH:
+        raise ValueError('Query is too long')
     query = query.strip()
     if not query:
         raise ValueError('Missing "query" key in request body')
-    if len(query) > MAX_QUERY_LENGTH:
-        raise ValueError('Query is too long')
     return query
 
 

--- a/api/tests/test_utils.py
+++ b/api/tests/test_utils.py
@@ -31,6 +31,12 @@ class UtilsTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'Query is too long'):
             validate_request_payload({"query": "x" * (MAX_QUERY_LENGTH + 1)})
 
+    def test_validate_request_payload_rejects_overlong_raw_query(self):
+        with self.assertRaisesRegex(ValueError, 'Query is too long'):
+            validate_request_payload(
+                {"query": " " * MAX_QUERY_LENGTH + "x"}
+            )
+
     def test_validate_request_payload_accepts_maximum_length_query(self):
         query = "x" * MAX_QUERY_LENGTH
 

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -704,6 +704,7 @@ if ! grep -Fq "FakeOpenAIClient" "$TEST_CLASSIFICATION" ||
   ! grep -Fq "test_validate_classification_weights_requires_expected_keys" "$TEST_CLASSIFICATION" ||
   ! grep -Fq "test_validate_classification_weights_rejects_invalid_values" "$TEST_CLASSIFICATION" ||
   ! grep -Fq "test_generate_classification_wraps_malformed_weight_errors" "$TEST_CLASSIFICATION" ||
+  ! grep -Fq "test_validate_request_payload_rejects_overlong_raw_query" "$TEST_UTILS" ||
   ! grep -Fq "extract_json_object_returns_empty_dict_without_stdout" "$TEST_UTILS"; then
   printf '%s\n' "Tests must cover fake OpenAI clients, classification schemas, and quiet JSON parse failures." >&2
   exit 1


### PR DESCRIPTION
## Summary

- reject overlong query strings before whitespace trimming
- add a regression for padded requests that previously bypassed the limit
- preserve the boundary in repository documentation and baseline checks

## Why

The previous validator measured only the normalized query. An authenticated caller could send a very large whitespace-padded string that normalized to a tiny value and bypassed the documented application-level request boundary.

## Validation

- `PATH=/tmp/gpt-docs-api-py310/bin:$PATH make verify`
- `git diff --check`

## Follow-up

- #36 tracks the separate bundled-extension/authentication trust-model mismatch.
