### PR TITLE
fix: authenticate bundled extension clients

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@
 
 - Detected references to OpenAI, Pinecone, AWS, and Twilio. Keep API keys, OAuth credentials, tokens, and account-specific values in local configuration only.
 - Set `GPT_DOCS_API_KEY` on deployments that expose `/ask` or `/classify/builder`. Callers must send the same value in `X-GPT-Docs-API-Key` or `Authorization: Bearer <token>` before those routes read request bodies or spend server-side OpenAI/Pinecone credentials.
+- Extension clients require a user-supplied HTTPS API URL and browser-session API key; never ship the deployment's shared secret.
 - Set `OPENAI_API_KEY`, `PINECONE_API_KEY`, `PINECONE_ENVIRONMENT`, and AWS credentials only in local or deployment environment configuration.
 - Keep `/ask` and `/classify/builder` behind the shared caller API-key guard or a stronger API Gateway/JWT authorizer. Public asset routes may remain unauthenticated, but public asset routes must stay path-bound to `api/chalicelib/public`.
 - Keep request query validation bounded by a maximum query length before routes invoke OpenAI, Pinecone, DynamoDB, or cache helpers.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,23 @@
 # Changes
 
+## 2026-06-26T23:40:00Z
+
+- **Priority:** P0 authentication compatibility and credential containment.
+- **Summary:** Extension clients require a user-supplied HTTPS API URL and browser-session API key; never ship the deployment's shared secret.
+- **Work:** Added mirrored Manifest V3 options/background assets, session-only
+  key storage, fixed-route authenticated request helpers, and CORS parity for
+  `/ask` and `/classify/builder`.
+- **Tests:** All 65 API tests, four Make aliases, `make verify`, external-path
+  `make check`, the 6,313-entry Chalice package check, thirteen hostile mutations,
+  extension rendering/authentication checks, leak scanning, and diff checks
+  passed without live service calls.
+- **Finding:** Both bundled clients omitted credentials, and the classification
+  route lacked the CORS configuration required for its custom API-key header.
+- **Blocker:** The repository owner's hosted deployment still needs a separate
+  identity-aware service before it can safely support unrelated public users.
+- **Next action:** Complete local gates, hostile mutations, review, hosted
+  checks, and exact-head merge for issue 36.
+
 ## 2026-06-26T22:48:23Z
 
 - **Priority:** Security and request resource boundaries.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build check compile lint package-check test verify
+.PHONY: build check compile lint mutations package-check test verify
 
 override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
@@ -11,6 +11,9 @@ build: compile
 
 compile:
 	@cd "$(ROOT)" && python "$(ROOT)/scripts/check-python-syntax.py" api/app.py api/chalicelib api/tests
+
+mutations:
+	@cd "$(ROOT)" && PYTHONDONTWRITEBYTECODE=1 python "$(ROOT)/scripts/test-extension-auth-mutations.py"
 
 check:
 	@"$(ROOT)/scripts/check-baseline.sh"

--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ When the required SDK or runtime is unavailable, use static checks and source re
   `/classify/builder`. Callers must send the same value in
   `X-GPT-Docs-API-Key` or `Authorization: Bearer <token>` before those routes
   read request bodies or spend server-side OpenAI/Pinecone credentials.
+- Extension clients require a user-supplied HTTPS API URL and browser-session API key; never ship the deployment's shared secret. Open the extension options
+  page after each browser restart, configure the HTTPS base URL for your own
+  deployment, and enter its key. The base URL persists locally; the key uses
+  memory-only `chrome.storage.session`. The deployment must allow the Twilio
+  Docs origins, `Content-Type`, and `X-GPT-Docs-API-Key` through CORS.
+  Because session storage is a Chrome 102+ Manifest V3 API, both bundled
+  manifests declare Chrome 102 as their minimum version.
 - Set `OPENAI_API_KEY`, `PINECONE_API_KEY`, `PINECONE_ENVIRONMENT`, and AWS
   credentials only in local or deployment environment configuration.
 
@@ -115,6 +122,9 @@ When the required SDK or runtime is unavailable, use static checks and source re
   a stronger API Gateway/JWT authorizer. Public asset routes may remain
   unauthenticated, but public asset routes must stay path-bound to
   `api/chalicelib/public`.
+- Keep bundled extension requests limited to the fixed `/ask` and
+  `/classify/builder` routes. Do not persist user keys in local or sync storage,
+  include them in logs, or accept non-HTTPS API origins.
 - Keep the maximum query length applied to the raw request value before trimming
   or invoking OpenAI, Pinecone, DynamoDB, or cache helpers.
 - DynamoDB cache entries expire after one day in application reads and include

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,6 +40,10 @@ Helpful reports include:
 
 For web services, APIs, sockets, or scraping workflows, prioritize reports involving authentication bypass, authorization errors, injection, server-side request forgery, unsafe deserialization, credential leakage, data exposure, or denial-of-service conditions. Use test accounts and minimal proof-of-concept traffic only.
 
+Extension clients require a user-supplied HTTPS API URL and browser-session API key; never ship the deployment's shared secret. Keep browser keys in
+`chrome.storage.session`, limit requests to the two authenticated API routes,
+and require CORS to admit the API-key header without enabling credentials.
+
 Validate the maximum raw query length before trimming whitespace so padded
 requests cannot bypass the application-level resource boundary.
 

--- a/VISION.md
+++ b/VISION.md
@@ -14,6 +14,8 @@ quality gates live in [`README.md`](README.md).
 The goal is to keep the experiment useful, testable, and safe around API keys,
 documentation crawling, and generated answers.
 
+Extension clients require a user-supplied HTTPS API URL and browser-session API key; never ship the deployment's shared secret.
+
 The current focus is:
 
 Priority:

--- a/api/app.py
+++ b/api/app.py
@@ -357,7 +357,7 @@ def hello_world():
     return resp
 
 
-@app.route('/classify/builder', methods=['POST'])
+@app.route('/classify/builder', methods=['POST'], cors=cors_config)
 def classify_builder():
     """
     An endpoint for classifying users based on the question they ask.

--- a/api/chalicelib/public/background.js
+++ b/api/chalicelib/public/background.js
@@ -1,0 +1,28 @@
+chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
+  if (
+    !message ||
+    message.type !== "getClientConfiguration" ||
+    sender.id !== chrome.runtime.id
+  ) {
+    return false;
+  }
+
+  chrome.storage.local.get(["gptDocsApiBaseUrl"], function (localValues) {
+    if (chrome.runtime.lastError) {
+      sendResponse({ apiBaseUrl: "", apiKey: "" });
+      return;
+    }
+    chrome.storage.session.get(["gptDocsApiKey"], function (sessionValues) {
+      if (chrome.runtime.lastError) {
+        sendResponse({ apiBaseUrl: "", apiKey: "" });
+        return;
+      }
+      sendResponse({
+        apiBaseUrl: localValues.gptDocsApiBaseUrl || "",
+        apiKey: sessionValues.gptDocsApiKey || "",
+      });
+    });
+  });
+
+  return true;
+});

--- a/api/chalicelib/public/content.js
+++ b/api/chalicelib/public/content.js
@@ -28,6 +28,67 @@ function safeHttpUrl(value) {
   return null;
 }
 
+function normalizeApiBaseUrl(value) {
+  try {
+    var parsed = new URL(String(value).trim());
+    if (
+      parsed.protocol !== "https:" ||
+      parsed.username ||
+      parsed.password ||
+      parsed.search ||
+      parsed.hash
+    ) {
+      return null;
+    }
+    return parsed.href.replace(/\/+$/, "");
+  } catch (error) {
+    return null;
+  }
+}
+
+function loadClientConfiguration() {
+  return new Promise(function (resolve) {
+    chrome.runtime.sendMessage(
+      { type: "getClientConfiguration" },
+      function (configuration) {
+        if (chrome.runtime.lastError) {
+          resolve({});
+          return;
+        }
+        resolve(configuration || {});
+      },
+    );
+  });
+}
+
+async function requestApi(route, payload) {
+  if (route !== "/ask" && route !== "/classify/builder") {
+    throw new Error("Unsupported API route.");
+  }
+
+  var configuration = await loadClientConfiguration();
+  var apiBaseUrl = normalizeApiBaseUrl(configuration.apiBaseUrl);
+  var apiKey = String(configuration.apiKey || "").trim();
+  if (!apiBaseUrl || !apiKey) {
+    throw new Error(
+      "Configure an HTTPS API URL and browser-session API key in extension options.",
+    );
+  }
+
+  var response = await fetch(apiBaseUrl + route, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-GPT-Docs-API-Key": apiKey,
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP error! Status: ${response.status}`);
+  }
+  return response.json();
+}
+
 // Create a new <style> element
 var styleElement = document.createElement("style");
 styleElement.type = "text/css";
@@ -176,28 +237,8 @@ function addResponse(text, links, parentElement) {
 }
 
 async function sendAhoy(query) {
-  // Define the endpoint URL
-  const url = "https://gpt-docs.api.garethpaul.com/classify/builder";
-
-  // Define the request options
-  const requestOptions = {
-    method: "POST", // Specify the request method
-    headers: {
-      "Content-Type": "application/json", // Set the content type to JSON
-    },
-    body: JSON.stringify(query), // Convert the query object to a JSON string
-  };
-
   try {
-    // Make the fetch request and handle the response
-    const response = await fetch(url, requestOptions);
-    if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
-
-    // Parse the response JSON
-    const responseData = await response.json();
-    return responseData;
+    return await requestApi("/classify/builder", query);
   } catch (error) {
     console.error("Error making POST request:", error);
     return null;
@@ -356,41 +397,27 @@ function addModal(b) {
       if (existingResponse) {
         existingResponse.remove();
       }
-      // Make an api request to http://localhost:3000/ask
-      // with the input value as the query
-      // and the response data as the response
-      // and the modal as the modal
       createLoader(modal);
-      fetch("https://wj2mszjum0.execute-api.us-west-2.amazonaws.com/api/ask", {
-        //fetch("http://localhost:8000/ask", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
+      requestApi("/ask", {
+        query: input.value,
+      }).then((data) => {
+        // remove the loader
+        removeLoader(modal);
+        // if there is an existing response remove it
+        addResponse(data.response, data.links, modal);
+        // Send the data to ahoy
+        sendAhoy({
           query: input.value,
-        }),
-      }).then((response) => {
-        response.json().then((data) => {
-          // remove the loader
-          removeLoader(modal);
-          // if there is an existing response remove it
-          addResponse(data.response, data.links, modal);
-          // Send the data to ahoy
-          sendAhoy({
-            query: input.value,
-          }).then((response) => {
-            // if the response is successful
-            if (response.status === 200) {
-              // log the response
-              if (response.data) {
-                analytics.track("user_type", response.data);
-              }
-            }
-          });
-          // clear the input value
-          clearInput();
+        }).then((response) => {
+          if (response && response.weights) {
+            analytics.track("user_type", response.weights);
+          }
         });
+        // clear the input value
+        clearInput();
+      }).catch((error) => {
+        removeLoader(modal);
+        addResponse(error.message, [], modal);
       });
     });
 

--- a/api/chalicelib/public/manifest.json
+++ b/api/chalicelib/public/manifest.json
@@ -1,5 +1,6 @@
 {
   "manifest_version": 3,
+  "minimum_chrome_version": "102",
   "name": "GPT Dev Docs",
   "version": "1.0",
   "description": "Add GPT Dev Docs to Twilio Docs",
@@ -21,8 +22,13 @@
   "permissions": [
     "activeTab",
     "tabs",
-    "management"
+    "management",
+    "storage"
   ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "options_page": "options.html",
   "web_accessible_resources": [
     {
       "resources": ["logo-nav.svg", "question.svg", "gpt-docs-nav.png"],

--- a/api/chalicelib/public/options.html
+++ b/api/chalicelib/public/options.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>GPT Dev Docs Settings</title>
+    <style>
+      body { font: 16px system-ui, sans-serif; margin: 2rem; max-width: 42rem; }
+      label { display: block; font-weight: 600; margin-top: 1rem; }
+      input { box-sizing: border-box; margin-top: 0.4rem; padding: 0.6rem; width: 100%; }
+      button { margin-top: 1.25rem; padding: 0.6rem 1rem; }
+      #status { min-height: 1.5rem; }
+    </style>
+  </head>
+  <body>
+    <h1>GPT Dev Docs Settings</h1>
+    <p>Configure your own authenticated GPT Docs API deployment. The API key stays only for this browser session.</p>
+    <form id="settingsForm">
+      <label for="apiBaseUrl">HTTPS API base URL</label>
+      <input id="apiBaseUrl" name="apiBaseUrl" type="url" required placeholder="https://api.example.com/api">
+      <label for="apiKey">API key</label>
+      <input id="apiKey" name="apiKey" type="password" required autocomplete="off">
+      <button type="submit">Save for this session</button>
+    </form>
+    <p id="status" role="status" aria-live="polite"></p>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/api/chalicelib/public/options.js
+++ b/api/chalicelib/public/options.js
@@ -1,0 +1,56 @@
+function normalizeApiBaseUrl(value) {
+  try {
+    var parsed = new URL(String(value).trim());
+    if (
+      parsed.protocol !== "https:" ||
+      parsed.username ||
+      parsed.password ||
+      parsed.search ||
+      parsed.hash
+    ) {
+      return null;
+    }
+    return parsed.href.replace(/\/+$/, "");
+  } catch (error) {
+    return null;
+  }
+}
+
+async function saveClientConfiguration(storage, apiBaseUrl, apiKey) {
+  var normalizedBaseUrl = normalizeApiBaseUrl(apiBaseUrl);
+  var normalizedApiKey = String(apiKey || "").trim();
+  if (!normalizedBaseUrl) {
+    throw new Error("Enter a valid HTTPS API URL.");
+  }
+  if (!normalizedApiKey) {
+    throw new Error("Enter an API key for this browser session.");
+  }
+
+  await storage.local.set({ gptDocsApiBaseUrl: normalizedBaseUrl });
+  await storage.session.set({ gptDocsApiKey: normalizedApiKey });
+}
+
+// Wire options page
+var settingsForm = document.getElementById("settingsForm");
+var apiBaseUrlInput = document.getElementById("apiBaseUrl");
+var apiKeyInput = document.getElementById("apiKey");
+var statusElement = document.getElementById("status");
+
+chrome.storage.local.get(["gptDocsApiBaseUrl"], function (values) {
+  apiBaseUrlInput.value = values.gptDocsApiBaseUrl || "";
+});
+
+settingsForm.addEventListener("submit", function (event) {
+  event.preventDefault();
+  statusElement.textContent = "";
+  saveClientConfiguration(
+    chrome.storage,
+    apiBaseUrlInput.value,
+    apiKeyInput.value,
+  ).then(function () {
+    apiKeyInput.value = "";
+    statusElement.textContent = "Settings saved for this browser session.";
+  }).catch(function (error) {
+    statusElement.textContent = error.message;
+  });
+});

--- a/api/tests/test_app_auth.py
+++ b/api/tests/test_app_auth.py
@@ -36,9 +36,11 @@ class FakeChalice:
     def __init__(self, app_name):
         self.app_name = app_name
         self.current_request = None
+        self.routes = []
 
     def route(self, *args, **kwargs):
         def decorator(func):
+            self.routes.append((args, kwargs, func.__name__))
             return func
 
         return decorator
@@ -71,6 +73,22 @@ class AppAuthTests(unittest.TestCase):
 
     def tearDown(self):
         sys.modules.pop("app", None)
+
+    def test_authenticated_browser_routes_share_cors_configuration(self):
+        route_options = {
+            args[0]: kwargs
+            for args, kwargs, _ in self.app_module.app.routes
+        }
+
+        self.assertIs(route_options["/ask"]["cors"], self.app_module.cors_config)
+        self.assertIs(
+            route_options["/classify/builder"]["cors"],
+            self.app_module.cors_config,
+        )
+        self.assertIn(
+            GPT_DOCS_API_KEY_HEADER,
+            self.app_module.cors_config.kwargs["allow_headers"],
+        )
 
     def test_ask_rejects_unauthenticated_callers_before_body_or_model_work(self):
         request = FakeRequest(headers={}, json_body={"query": "How?"})

--- a/chrome_extension/background.js
+++ b/chrome_extension/background.js
@@ -1,0 +1,28 @@
+chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
+  if (
+    !message ||
+    message.type !== "getClientConfiguration" ||
+    sender.id !== chrome.runtime.id
+  ) {
+    return false;
+  }
+
+  chrome.storage.local.get(["gptDocsApiBaseUrl"], function (localValues) {
+    if (chrome.runtime.lastError) {
+      sendResponse({ apiBaseUrl: "", apiKey: "" });
+      return;
+    }
+    chrome.storage.session.get(["gptDocsApiKey"], function (sessionValues) {
+      if (chrome.runtime.lastError) {
+        sendResponse({ apiBaseUrl: "", apiKey: "" });
+        return;
+      }
+      sendResponse({
+        apiBaseUrl: localValues.gptDocsApiBaseUrl || "",
+        apiKey: sessionValues.gptDocsApiKey || "",
+      });
+    });
+  });
+
+  return true;
+});

--- a/chrome_extension/content.js
+++ b/chrome_extension/content.js
@@ -28,6 +28,67 @@ function safeHttpUrl(value) {
   return null;
 }
 
+function normalizeApiBaseUrl(value) {
+  try {
+    var parsed = new URL(String(value).trim());
+    if (
+      parsed.protocol !== "https:" ||
+      parsed.username ||
+      parsed.password ||
+      parsed.search ||
+      parsed.hash
+    ) {
+      return null;
+    }
+    return parsed.href.replace(/\/+$/, "");
+  } catch (error) {
+    return null;
+  }
+}
+
+function loadClientConfiguration() {
+  return new Promise(function (resolve) {
+    chrome.runtime.sendMessage(
+      { type: "getClientConfiguration" },
+      function (configuration) {
+        if (chrome.runtime.lastError) {
+          resolve({});
+          return;
+        }
+        resolve(configuration || {});
+      },
+    );
+  });
+}
+
+async function requestApi(route, payload) {
+  if (route !== "/ask" && route !== "/classify/builder") {
+    throw new Error("Unsupported API route.");
+  }
+
+  var configuration = await loadClientConfiguration();
+  var apiBaseUrl = normalizeApiBaseUrl(configuration.apiBaseUrl);
+  var apiKey = String(configuration.apiKey || "").trim();
+  if (!apiBaseUrl || !apiKey) {
+    throw new Error(
+      "Configure an HTTPS API URL and browser-session API key in extension options.",
+    );
+  }
+
+  var response = await fetch(apiBaseUrl + route, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-GPT-Docs-API-Key": apiKey,
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP error! Status: ${response.status}`);
+  }
+  return response.json();
+}
+
 // Create a new <style> element
 var styleElement = document.createElement("style");
 styleElement.type = "text/css";
@@ -176,29 +237,8 @@ function addResponse(text, links, parentElement) {
 }
 
 async function sendAhoy(query) {
-  // Define the endpoint URL
-  const url =
-    "https://wj2mszjum0.execute-api.us-west-2.amazonaws.com/api/classify/builder";
-
-  // Define the request options
-  const requestOptions = {
-    method: "POST", // Specify the request method
-    headers: {
-      "Content-Type": "application/json", // Set the content type to JSON
-    },
-    body: JSON.stringify(query), // Convert the query object to a JSON string
-  };
-
   try {
-    // Make the fetch request and handle the response
-    const response = await fetch(url, requestOptions);
-    if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
-
-    // Parse the response JSON
-    const responseData = await response.json();
-    return responseData;
+    return await requestApi("/classify/builder", query);
   } catch (error) {
     console.error("Error making POST request:", error);
     return null;
@@ -357,41 +397,27 @@ function addModal(b) {
       if (existingResponse) {
         existingResponse.remove();
       }
-      // Make an api request to http://localhost:3000/ask
-      // with the input value as the query
-      // and the response data as the response
-      // and the modal as the modal
       createLoader(modal);
-      fetch("https://wj2mszjum0.execute-api.us-west-2.amazonaws.com/api/ask", {
-        //fetch("http://localhost:8000/ask", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
+      requestApi("/ask", {
+        query: input.value,
+      }).then((data) => {
+        // remove the loader
+        removeLoader(modal);
+        // if there is an existing response remove it
+        addResponse(data.response, data.links, modal);
+        // Send the data to ahoy
+        sendAhoy({
           query: input.value,
-        }),
-      }).then((response) => {
-        response.json().then((data) => {
-          // remove the loader
-          removeLoader(modal);
-          // if there is an existing response remove it
-          addResponse(data.response, data.links, modal);
-          // Send the data to ahoy
-          sendAhoy({
-            query: input.value,
-          }).then((response) => {
-            // if the response is successful
-            if (response.status === 200) {
-              // log the response
-              if (response.data) {
-                analytics.track("user_type", response.data);
-              }
-            }
-          });
-          // clear the input value
-          clearInput();
+        }).then((response) => {
+          if (response && response.weights) {
+            analytics.track("user_type", response.weights);
+          }
         });
+        // clear the input value
+        clearInput();
+      }).catch((error) => {
+        removeLoader(modal);
+        addResponse(error.message, [], modal);
       });
     });
 

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -1,5 +1,6 @@
 {
   "manifest_version": 3,
+  "minimum_chrome_version": "102",
   "name": "GPT Dev Docs",
   "version": "1.0",
   "description": "Add GPT Dev Docs to Twilio Docs",
@@ -21,8 +22,13 @@
   "permissions": [
     "activeTab",
     "tabs",
-    "management"
+    "management",
+    "storage"
   ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "options_page": "options.html",
   "web_accessible_resources": [
     {
       "resources": ["logo-nav.svg", "question.svg", "gpt-docs-nav.png", "gpt-docs-nav.svg"],

--- a/chrome_extension/options.html
+++ b/chrome_extension/options.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>GPT Dev Docs Settings</title>
+    <style>
+      body { font: 16px system-ui, sans-serif; margin: 2rem; max-width: 42rem; }
+      label { display: block; font-weight: 600; margin-top: 1rem; }
+      input { box-sizing: border-box; margin-top: 0.4rem; padding: 0.6rem; width: 100%; }
+      button { margin-top: 1.25rem; padding: 0.6rem 1rem; }
+      #status { min-height: 1.5rem; }
+    </style>
+  </head>
+  <body>
+    <h1>GPT Dev Docs Settings</h1>
+    <p>Configure your own authenticated GPT Docs API deployment. The API key stays only for this browser session.</p>
+    <form id="settingsForm">
+      <label for="apiBaseUrl">HTTPS API base URL</label>
+      <input id="apiBaseUrl" name="apiBaseUrl" type="url" required placeholder="https://api.example.com/api">
+      <label for="apiKey">API key</label>
+      <input id="apiKey" name="apiKey" type="password" required autocomplete="off">
+      <button type="submit">Save for this session</button>
+    </form>
+    <p id="status" role="status" aria-live="polite"></p>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/chrome_extension/options.js
+++ b/chrome_extension/options.js
@@ -1,0 +1,56 @@
+function normalizeApiBaseUrl(value) {
+  try {
+    var parsed = new URL(String(value).trim());
+    if (
+      parsed.protocol !== "https:" ||
+      parsed.username ||
+      parsed.password ||
+      parsed.search ||
+      parsed.hash
+    ) {
+      return null;
+    }
+    return parsed.href.replace(/\/+$/, "");
+  } catch (error) {
+    return null;
+  }
+}
+
+async function saveClientConfiguration(storage, apiBaseUrl, apiKey) {
+  var normalizedBaseUrl = normalizeApiBaseUrl(apiBaseUrl);
+  var normalizedApiKey = String(apiKey || "").trim();
+  if (!normalizedBaseUrl) {
+    throw new Error("Enter a valid HTTPS API URL.");
+  }
+  if (!normalizedApiKey) {
+    throw new Error("Enter an API key for this browser session.");
+  }
+
+  await storage.local.set({ gptDocsApiBaseUrl: normalizedBaseUrl });
+  await storage.session.set({ gptDocsApiKey: normalizedApiKey });
+}
+
+// Wire options page
+var settingsForm = document.getElementById("settingsForm");
+var apiBaseUrlInput = document.getElementById("apiBaseUrl");
+var apiKeyInput = document.getElementById("apiKey");
+var statusElement = document.getElementById("status");
+
+chrome.storage.local.get(["gptDocsApiBaseUrl"], function (values) {
+  apiBaseUrlInput.value = values.gptDocsApiBaseUrl || "";
+});
+
+settingsForm.addEventListener("submit", function (event) {
+  event.preventDefault();
+  statusElement.textContent = "";
+  saveClientConfiguration(
+    chrome.storage,
+    apiBaseUrlInput.value,
+    apiKeyInput.value,
+  ).then(function () {
+    apiKeyInput.value = "";
+    statusElement.textContent = "Settings saved for this browser session.";
+  }).catch(function (error) {
+    statusElement.textContent = error.message;
+  });
+});

--- a/docs/plans/2026-06-26-extension-client-auth-design.md
+++ b/docs/plans/2026-06-26-extension-client-auth-design.md
@@ -1,0 +1,99 @@
+# Extension Client Authentication Design
+
+Status: approved
+
+## Problem
+
+Both checked-in Manifest V3 clients call `/ask` and `/classify/builder`
+without either credential accepted by the deployed API. Embedding the
+deployment's shared `GPT_DOCS_API_KEY` in either extension bundle would expose
+the server secret to every installer.
+
+## Evidence
+
+- `api/chalicelib/auth.py` accepts `X-GPT-Docs-API-Key` or a bearer token and
+  fails closed when the server secret is absent or mismatched.
+- `api/chalicelib/public/content.js` and `chrome_extension/content.js` make both
+  API requests without an authorization header.
+- Both manifests are Manifest V3 extension bundles, so the same client model
+  can cover the deployed public assets and the source extension.
+- Chrome documents that content scripts run in an isolated world and can
+  message extension contexts.
+- Chrome documents that `storage.session` is memory-only, is cleared on browser
+  restart, is not exposed to content scripts by default, and requires Chrome
+  102+ in Manifest V3.
+- Chrome documents that content-script cross-origin requests remain subject to
+  the page origin and CORS, so the configured self-hosted API must explicitly
+  permit the Twilio Docs origins.
+
+Official references:
+
+- https://developer.chrome.com/docs/extensions/develop/concepts/content-scripts
+- https://developer.chrome.com/docs/extensions/reference/api/storage
+- https://developer.chrome.com/docs/extensions/develop/concepts/network-requests
+
+## Options
+
+### 1. Ship the deployment secret
+
+Rejected. A bundled key is public and recreates the unauthenticated spending
+boundary under a recoverable shared credential.
+
+### 2. Add a hosted identity-aware proxy
+
+Rejected for this maintenance change. It would require a new account system,
+token lifecycle, authorization model, and production service.
+
+### 3. Require per-user self-hosted configuration
+
+Selected. Users provide their own HTTPS API base URL and their own deployment
+key. The base URL persists locally; the key remains only in
+`chrome.storage.session` and must be re-entered after browser restart.
+
+## Design
+
+Add one options page and one background service worker to each mirrored
+extension bundle. The options page validates an HTTPS base URL, stores it in
+`chrome.storage.local`, and stores the key in `chrome.storage.session`. The
+background worker returns the current configuration only to messages from its
+own extension, and the content script requests it through `chrome.runtime`.
+
+The content script builds fixed `/ask` and `/classify/builder` URLs from the
+configured base URL, adds `X-GPT-Docs-API-Key`, and performs the existing CORS
+requests. It never accepts an arbitrary route from page content, never logs the
+key, and fails with a deterministic configuration message before network work
+when either value is missing.
+
+Both extension directories keep byte-identical authentication helpers,
+background workers, and options assets. Existing response rendering remains
+text-only and URL-filtered.
+
+## Error Handling
+
+- Missing configuration: show a user-facing prompt to open extension options;
+  do not call `fetch`.
+- Invalid base URL: reject it in the options page and again in the content
+  helper; require HTTPS and remove trailing slashes.
+- API 401/503 or CORS/network failure: preserve the existing failed-request
+  path without exposing credentials or server internals.
+- Browser restart: the endpoint remains, but the session key is absent until
+  the user enters it again.
+
+## Validation
+
+- Node VM tests prove both routes use the configured base URL and API-key
+  header.
+- Tests prove missing or invalid configuration makes zero network requests.
+- Tests prove the key is stored only in `storage.session`, never in local or
+  sync storage.
+- Baseline contracts require mirrored assets, Manifest V3 storage/options/
+  background declarations, guidance, and completed plan evidence.
+- Run `make verify`, extension rendering checks, syntax checks, hostile
+  mutations, secret scanning, and hosted CodeQL.
+
+## Residual Risk
+
+The user-supplied key is available to the extension process while the browser
+session is active and the self-hosted API must configure CORS correctly. The
+design does not provide per-user authorization for the repository owner's
+hosted deployment; that requires a separate identity-aware service.

--- a/docs/plans/2026-06-26-extension-client-auth.md
+++ b/docs/plans/2026-06-26-extension-client-auth.md
@@ -1,0 +1,173 @@
+# Extension Client Authentication Implementation Plan
+
+status: completed
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+**Goal:** Make both bundled extension clients compatible with authenticated self-hosted API deployments without shipping a shared server secret.
+
+**Architecture:** Store the user-selected HTTPS API base URL in extension-local storage and the user-supplied API key in browser-session storage. A background worker exposes configuration through extension messaging, while mirrored content scripts add the fixed API-key header to the two supported routes and refuse network calls when configuration is unavailable.
+
+**Tech Stack:** Manifest V3, vanilla JavaScript, Chrome Storage and Runtime APIs, Node VM contract tests, shell/Python baseline gates.
+
+---
+
+### Task 1: Add failing client-auth contracts
+
+**Files:**
+- Create: `scripts/check-extension-auth.sh`
+- Modify: `Makefile`
+
+**Step 1: Write the failing test**
+
+Create a Node VM harness that loads each content script with mocked
+`chrome.runtime.sendMessage` and `fetch`. Require `/ask` and
+`/classify/builder` requests to use the configured HTTPS base URL and
+`X-GPT-Docs-API-Key`, and require missing configuration to perform zero fetches.
+
+**Step 2: Run test to verify it fails**
+
+Run: `./scripts/check-extension-auth.sh`
+
+Expected: FAIL because no configuration messaging or API-key header exists.
+
+### Task 2: Add extension configuration assets
+
+**Files:**
+- Create: `chrome_extension/background.js`
+- Create: `chrome_extension/options.html`
+- Create: `chrome_extension/options.js`
+- Create: `api/chalicelib/public/background.js`
+- Create: `api/chalicelib/public/options.html`
+- Create: `api/chalicelib/public/options.js`
+- Modify: `chrome_extension/manifest.json`
+- Modify: `api/chalicelib/public/manifest.json`
+
+**Step 1: Write failing storage contracts**
+
+Extend the auth harness to require HTTPS endpoint validation, local endpoint
+storage, session-only key storage, mirrored files, and Manifest V3 declarations
+for `storage`, `options_page`, and the background service worker.
+
+**Step 2: Run test to verify it fails**
+
+Run: `./scripts/check-extension-auth.sh`
+
+Expected: FAIL because the assets and manifest declarations are absent.
+
+**Step 3: Write minimal implementation**
+
+Implement options save/restore and a message handler that returns the local
+endpoint plus session key. Do not persist the key to local or sync storage.
+
+**Step 4: Run test to verify it passes**
+
+Run: `./scripts/check-extension-auth.sh`
+
+Expected: PASS for configuration storage and messaging contracts.
+
+### Task 3: Authenticate both API flows
+
+**Files:**
+- Modify: `chrome_extension/content.js`
+- Modify: `api/chalicelib/public/content.js`
+- Modify: `scripts/check-extension-auth.sh`
+
+**Step 1: Run the existing failing route contracts**
+
+Run: `./scripts/check-extension-auth.sh`
+
+Expected: FAIL because both requests still omit the configured credentials.
+
+**Step 2: Write minimal implementation**
+
+Add one configuration loader and one fixed-route request helper. Route both
+classification and answer requests through it, require HTTPS configuration,
+and return a deterministic setup error without calling `fetch` when absent.
+
+**Step 3: Run test to verify it passes**
+
+Run: `./scripts/check-extension-auth.sh`
+
+Expected: PASS for both routes and both mirrored clients.
+
+### Task 4: Preserve repository policy and guidance
+
+**Files:**
+- Modify: `scripts/check-baseline.sh`
+- Modify: `AGENTS.md`
+- Modify: `README.md`
+- Modify: `SECURITY.md`
+- Modify: `VISION.md`
+- Modify: `CHANGES.md`
+- Modify: `docs/plans/2026-06-26-extension-client-auth.md`
+
+**Step 1: Add failing baseline contracts**
+
+Require the completed plan, mirrored extension assets, session-only key
+guidance, and both route/header contracts.
+
+**Step 2: Run test to verify it fails**
+
+Run: `make check`
+
+Expected: FAIL until guidance and plan evidence are complete.
+
+**Step 3: Update documentation and evidence**
+
+Document the self-hosted trust model, browser-session key lifetime, HTTPS/CORS
+requirement, validation commands, findings, blockers, and next action.
+
+**Step 4: Run focused and full validation**
+
+Run: `make verify`
+
+Expected: all Python, JavaScript, extension, syntax, and baseline checks pass
+without live credentials.
+
+### Task 5: Review and ship exact head
+
+**Files:**
+- Modify only files required by verified review findings.
+
+**Step 1: Run hostile mutations and leak checks**
+
+Mutate each credential route, storage boundary, manifest declaration, mirror
+contract, and guidance requirement independently; confirm the gates reject
+each mutation. Run `gitleaks detect --no-git --source .` and
+`git diff --check`.
+
+**Step 2: Commit and open the pull request**
+
+Commit the focused change, push the branch, and open a PR linked to issue 36.
+
+**Step 3: Run Codex review and hosted checks**
+
+Run the branch review helper, skipping only authentication-only tool failure.
+Require Check and CodeQL on the exact PR head.
+
+**Step 4: Merge exact head**
+
+Merge only with `--match-head-commit` after all required checks are green, then
+verify issue 36 closes and `main` remains healthy.
+
+## Verification Completed
+
+- The red-first Node contract failed before configuration assets and request
+  helpers existed; both authenticated extension routes passed after the minimal
+  implementation.
+- The red-first Python route contract failed because `/classify/builder` lacked
+  CORS and passed after it shared the authenticated `/ask` configuration.
+- The complete API suite passed with 65 tests.
+- All four Make gates passed with the maintained Python 3.10 dependency
+  environment, and `make verify` passed.
+- The external-directory Make gate passed using the repository Makefile.
+- Thirteen hostile extension authentication mutations were rejected across
+  routes, headers, URL validation, configuration messaging, sender ownership,
+  session storage, manifests, mirrored assets, and CORS.
+- Extension rendering, JavaScript syntax, Python syntax, dependency-lock,
+  whitespace, current-tree leak checks, and the 6,313-entry Chalice package
+  check passed.
+- No live OpenAI, Pinecone, DynamoDB, AWS, Twilio, API Gateway, browser publication, or deployment operation was executed.
+- Codex review and hosted Check/CodeQL remain the merge gates for the exact PR
+  head.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -57,6 +57,9 @@ RETRIEVAL_METADATA_ACCESSOR_PLAN="$ROOT_DIR/docs/plans/2026-06-17-retrieval-meta
 OPENAI_CLIENT_PLAN="$ROOT_DIR/docs/plans/2026-06-17-002-refactor-openai-client-v2-plan.md"
 BYTECODE_FREE_PLAN="$ROOT_DIR/docs/plans/2026-06-18-bytecode-free-python-gates.md"
 PACKAGE_SIGNAL_PLAN="$ROOT_DIR/docs/plans/2026-06-18-chalice-package-signal-forwarding.md"
+EXTENSION_AUTH_DESIGN="$ROOT_DIR/docs/plans/2026-06-26-extension-client-auth-design.md"
+EXTENSION_AUTH_PLAN="$ROOT_DIR/docs/plans/2026-06-26-extension-client-auth.md"
+EXTENSION_AUTH_CHECK="$ROOT_DIR/scripts/check-extension-auth.sh"
 SYNTAX_CHECK="$ROOT_DIR/scripts/check-python-syntax.py"
 
 require_file() {
@@ -121,9 +124,19 @@ for path in \
   "docs/plans/2026-06-17-002-refactor-openai-client-v2-plan.md" \
   "docs/plans/2026-06-18-bytecode-free-python-gates.md" \
   "docs/plans/2026-06-18-chalice-package-signal-forwarding.md" \
+  "docs/plans/2026-06-26-extension-client-auth-design.md" \
+  "docs/plans/2026-06-26-extension-client-auth.md" \
+  "chrome_extension/background.js" \
+  "chrome_extension/options.html" \
+  "chrome_extension/options.js" \
+  "api/chalicelib/public/background.js" \
+  "api/chalicelib/public/options.html" \
+  "api/chalicelib/public/options.js" \
   "scripts/check-python-syntax.py" \
   "scripts/check-dependency-lock.py" \
   "scripts/check-extension-rendering.sh" \
+  "scripts/check-extension-auth.sh" \
+  "scripts/test-extension-auth-mutations.py" \
   "scripts/verify-chalice-package.sh" \
   "scripts/check-baseline.sh"; do
   require_file "$path"
@@ -1272,9 +1285,45 @@ if (
     )
 PY
 
+extension_auth_guidance="Extension clients require a user-supplied HTTPS API URL and browser-session API key; never ship the deployment's shared secret."
+for document in "$ROOT_DIR/AGENTS.md" "$README" "$ROOT_DIR/SECURITY.md" "$VISION" "$CHANGES"; do
+  if ! grep -Fq "$extension_auth_guidance" "$document"; then
+    printf '%s\n' "$document must document the extension authentication trust model." >&2
+    exit 1
+  fi
+done
+
+python3 - "$EXTENSION_AUTH_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text(encoding="utf-8")
+statuses = re.findall(r"^status: .+$", plan, flags=re.MULTILINE)
+verification = plan.split("## Verification Completed\n", 1)[-1]
+required = (
+    "both authenticated extension routes passed",
+    "complete API suite passed",
+    "All four Make gates passed",
+    "external-directory Make gate passed",
+    "hostile extension authentication mutations were rejected",
+    "No live OpenAI, Pinecone, DynamoDB, AWS, Twilio, API Gateway, browser publication, or deployment operation was executed",
+)
+if (
+    statuses != ["status: completed"]
+    or "## Verification Completed\n" not in plan
+    or any(item not in verification for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run|not yet)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Extension client authentication plan must record completed verification."
+    )
+PY
+
 PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="$ROOT_DIR/api" python -m unittest discover -s "$ROOT_DIR/api/tests"
 python "$SYNTAX_CHECK" "$ROOT_DIR/api/app.py" "$ROOT_DIR/api/chalicelib" "$ROOT_DIR/api/tests"
 "$EXTENSION_RENDERING_CHECK"
+"$EXTENSION_AUTH_CHECK"
 
 generated_python_artifacts=$(
   find "$ROOT_DIR" \

--- a/scripts/check-extension-auth.sh
+++ b/scripts/check-extension-auth.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+for directory in chrome_extension api/chalicelib/public; do
+  for file in background.js options.html options.js; do
+    if [ ! -f "$ROOT_DIR/$directory/$file" ]; then
+      printf '%s\n' "Required extension authentication asset is missing: $directory/$file" >&2
+      exit 1
+    fi
+  done
+
+  node --check "$ROOT_DIR/$directory/content.js"
+  node --check "$ROOT_DIR/$directory/background.js"
+  node --check "$ROOT_DIR/$directory/options.js"
+done
+
+node - "$ROOT_DIR" <<'EOF'
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const root = process.argv[2];
+const directories = ["chrome_extension", "api/chalicelib/public"];
+
+function loadHelpers(relativePath, marker, context) {
+  const file = path.join(root, relativePath);
+  const source = fs.readFileSync(file, "utf8");
+  const markerIndex = source.indexOf(marker);
+  assert.notEqual(markerIndex, -1, `${relativePath} is missing ${marker}`);
+  vm.createContext(context);
+  vm.runInContext(source.slice(0, markerIndex), context, { filename: file });
+  return source;
+}
+
+async function verifyContentScript(directory) {
+  const fetchCalls = [];
+  let configuration = {
+    apiBaseUrl: "https://self-hosted.example/api/",
+    apiKey: "user-session-key",
+  };
+  const context = {
+    URL,
+    fetch: async (url, options) => {
+      fetchCalls.push({ url, options });
+      return { ok: true, status: 200, json: async () => ({ ok: true }) };
+    },
+    chrome: {
+      runtime: {
+        sendMessage(message, callback) {
+          assert.equal(message.type, "getClientConfiguration");
+          callback(configuration);
+        },
+      },
+    },
+  };
+  loadHelpers(
+    `${directory}/content.js`,
+    "// Create a new <style> element",
+    context,
+  );
+
+  assert.equal(
+    context.normalizeApiBaseUrl("https://self-hosted.example/api/"),
+    "https://self-hosted.example/api",
+  );
+  assert.equal(context.normalizeApiBaseUrl("http://self-hosted.example"), null);
+  assert.equal(context.normalizeApiBaseUrl("https://user:pass@self-hosted.example"), null);
+  assert.equal(context.normalizeApiBaseUrl("https://self-hosted.example/api?mode=test"), null);
+  assert.equal(context.normalizeApiBaseUrl("https://self-hosted.example/api#fragment"), null);
+
+  await context.requestApi("/ask", { query: "How do I send SMS?" });
+  await context.requestApi("/classify/builder", { query: "How do I send SMS?" });
+  assert.equal(fetchCalls.length, 2);
+  assert.deepEqual(fetchCalls.map((call) => call.url), [
+    "https://self-hosted.example/api/ask",
+    "https://self-hosted.example/api/classify/builder",
+  ]);
+  for (const call of fetchCalls) {
+    assert.equal(call.options.method, "POST");
+    assert.equal(call.options.headers["Content-Type"], "application/json");
+    assert.equal(call.options.headers["X-GPT-Docs-API-Key"], "user-session-key");
+  }
+
+  configuration = { apiBaseUrl: "https://self-hosted.example/api", apiKey: "" };
+  await assert.rejects(
+    context.requestApi("/ask", { query: "blocked" }),
+    /Configure an HTTPS API URL and browser-session API key/,
+  );
+  assert.equal(fetchCalls.length, 2);
+  configuration = { apiBaseUrl: "http://insecure.example", apiKey: "key" };
+  await assert.rejects(
+    context.requestApi("/ask", { query: "blocked" }),
+    /Configure an HTTPS API URL and browser-session API key/,
+  );
+  assert.equal(fetchCalls.length, 2);
+  await assert.rejects(
+    context.requestApi("/arbitrary", { query: "blocked" }),
+    /Unsupported API route/,
+  );
+  assert.equal(fetchCalls.length, 2);
+}
+
+function verifyBackground(directory) {
+  let listener;
+  const context = {
+    chrome: {
+      runtime: {
+        id: "extension",
+        onMessage: {
+          addListener(callback) {
+            listener = callback;
+          },
+        },
+      },
+      storage: {
+        local: {
+          get(keys, callback) {
+            assert.equal(JSON.stringify(keys), '["gptDocsApiBaseUrl"]');
+            callback({ gptDocsApiBaseUrl: "https://self-hosted.example/api" });
+          },
+        },
+        session: {
+          get(keys, callback) {
+            assert.equal(JSON.stringify(keys), '["gptDocsApiKey"]');
+            callback({ gptDocsApiKey: "user-session-key" });
+          },
+        },
+      },
+    },
+  };
+  const source = fs.readFileSync(path.join(root, directory, "background.js"), "utf8");
+  vm.createContext(context);
+  vm.runInContext(source, context, { filename: `${directory}/background.js` });
+  assert.equal(typeof listener, "function");
+  assert.equal(
+    listener(
+      { type: "getClientConfiguration" },
+      { id: "different-extension" },
+      () => { throw new Error("foreign senders must not receive configuration"); },
+    ),
+    false,
+  );
+  let response;
+  const asynchronous = listener(
+    { type: "getClientConfiguration" },
+    { id: "extension" },
+    (value) => { response = value; },
+  );
+  assert.equal(asynchronous, true);
+  assert.equal(response.apiBaseUrl, "https://self-hosted.example/api");
+  assert.equal(response.apiKey, "user-session-key");
+}
+
+async function verifyOptions(directory) {
+  const writes = [];
+  const context = { URL };
+  loadHelpers(`${directory}/options.js`, "// Wire options page", context);
+  const storage = {
+    local: {
+      async set(value) { writes.push(["local", value]); },
+    },
+    session: {
+      async set(value) { writes.push(["session", value]); },
+    },
+    sync: {
+      async set() { throw new Error("API keys must not use sync storage"); },
+    },
+  };
+  await context.saveClientConfiguration(
+    storage,
+    "https://self-hosted.example/api/",
+    "user-session-key",
+  );
+  assert.equal(JSON.stringify(writes), JSON.stringify([
+    ["local", { gptDocsApiBaseUrl: "https://self-hosted.example/api" }],
+    ["session", { gptDocsApiKey: "user-session-key" }],
+  ]));
+  await assert.rejects(
+    context.saveClientConfiguration(storage, "http://insecure.example", "key"),
+    /HTTPS API URL/,
+  );
+  await assert.rejects(
+    context.saveClientConfiguration(
+      storage,
+      "https://user:pass@self-hosted.example",
+      "key",
+    ),
+    /HTTPS API URL/,
+  );
+}
+
+(async () => {
+  for (const directory of directories) {
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(root, directory, "manifest.json"), "utf8"),
+    );
+    assert.equal(manifest.manifest_version, 3);
+    assert.equal(manifest.minimum_chrome_version, "102");
+    assert.ok(manifest.permissions.includes("storage"));
+    assert.equal(manifest.options_page, "options.html");
+    assert.equal(manifest.background.service_worker, "background.js");
+    await verifyContentScript(directory);
+    verifyBackground(directory);
+    await verifyOptions(directory);
+  }
+
+  for (const file of ["background.js", "options.html", "options.js"]) {
+    assert.equal(
+      fs.readFileSync(path.join(root, directories[0], file), "utf8"),
+      fs.readFileSync(path.join(root, directories[1], file), "utf8"),
+      `${file} must stay mirrored`,
+    );
+  }
+  console.log("GPT Docs extension authentication checks passed.");
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+EOF

--- a/scripts/test-extension-auth-mutations.py
+++ b/scripts/test-extension-auth-mutations.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+AUTH_CHECK = ("scripts/check-extension-auth.sh",)
+PYTHON_CORS_CHECK = (
+    sys.executable,
+    "-m",
+    "unittest",
+    "api.tests.test_app_auth.AppAuthTests.test_authenticated_browser_routes_share_cors_configuration",
+)
+
+MUTATIONS = (
+    (
+        "chrome_extension/content.js",
+        '"X-GPT-Docs-API-Key": apiKey',
+        '"X-GPT-Docs-API-Key-Broken": apiKey',
+        AUTH_CHECK,
+    ),
+    (
+        "chrome_extension/content.js",
+        'route !== "/ask" && route !== "/classify/builder"',
+        'route !== "/asks" && route !== "/classify/builder"',
+        AUTH_CHECK,
+    ),
+    (
+        "chrome_extension/content.js",
+        'parsed.protocol !== "https:"',
+        'parsed.protocol !== "http:"',
+        AUTH_CHECK,
+    ),
+    (
+        "chrome_extension/content.js",
+        '{ type: "getClientConfiguration" }',
+        '{ type: "getClientConfigurationBroken" }',
+        AUTH_CHECK,
+    ),
+    (
+        "chrome_extension/content.js",
+        "if (!apiBaseUrl || !apiKey)",
+        "if (!apiBaseUrl && !apiKey)",
+        AUTH_CHECK,
+    ),
+    (
+        "chrome_extension/background.js",
+        "sender.id !== chrome.runtime.id",
+        "sender.id === chrome.runtime.id",
+        AUTH_CHECK,
+    ),
+    (
+        "chrome_extension/background.js",
+        'chrome.storage.session.get(["gptDocsApiKey"]',
+        'chrome.storage.local.get(["gptDocsApiKey"]',
+        AUTH_CHECK,
+    ),
+    (
+        "chrome_extension/options.js",
+        "await storage.session.set({ gptDocsApiKey: normalizedApiKey });",
+        "await storage.local.set({ gptDocsApiKey: normalizedApiKey });",
+        AUTH_CHECK,
+    ),
+    (
+        "chrome_extension/manifest.json",
+        '"storage"',
+        '"storage-broken"',
+        AUTH_CHECK,
+    ),
+    (
+        "chrome_extension/manifest.json",
+        '"minimum_chrome_version": "102"',
+        '"minimum_chrome_version": "101"',
+        AUTH_CHECK,
+    ),
+    (
+        "chrome_extension/manifest.json",
+        '"options_page": "options.html"',
+        '"options_page": "options-broken.html"',
+        AUTH_CHECK,
+    ),
+    (
+        "api/chalicelib/public/background.js",
+        "return true;",
+        "return true;\n// hostile mirror divergence",
+        AUTH_CHECK,
+    ),
+    (
+        "api/app.py",
+        "@app.route('/classify/builder', methods=['POST'], cors=cors_config)",
+        "@app.route('/classify/builder', methods=['POST'])",
+        PYTHON_CORS_CHECK,
+    ),
+)
+
+
+def copy_repository(destination):
+    shutil.copytree(
+        ROOT,
+        destination,
+        dirs_exist_ok=True,
+        ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc", "*.pyo"),
+    )
+
+
+def apply_mutation(root, relative_path, original, replacement):
+    path = root / relative_path
+    source = path.read_text(encoding="utf-8")
+    if source.count(original) != 1:
+        raise RuntimeError(f"mutation anchor is not unique: {relative_path}: {original}")
+    path.write_text(source.replace(original, replacement, 1), encoding="utf-8")
+
+
+def mutation_is_rejected(root, command):
+    environment = os.environ.copy()
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    environment["PYTHONPATH"] = str(root / "api")
+    if command == AUTH_CHECK:
+        invocation = [str(root / command[0])]
+    else:
+        invocation = list(command)
+    result = subprocess.run(
+        invocation,
+        cwd=root,
+        env=environment,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return result.returncode != 0
+
+
+def main():
+    for relative_path, original, replacement, command in MUTATIONS:
+        with tempfile.TemporaryDirectory(prefix="gpt-docs-auth-mutation-") as temp:
+            mutation_root = Path(temp) / "repo"
+            copy_repository(mutation_root)
+            apply_mutation(mutation_root, relative_path, original, replacement)
+            if not mutation_is_rejected(mutation_root, command):
+                raise SystemExit(f"hostile mutation survived: {relative_path}: {original}")
+    print(f"killed {len(MUTATIONS)} hostile extension authentication mutations")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- require a user-supplied HTTPS API origin and browser-session API key
- authenticate both bundled `/ask` and `/classify/builder` flows without shipping the server secret
- add Manifest V3 options/background assets, CORS parity, and deterministic route/storage contracts

## Security model
- API base URL persists in `chrome.storage.local`
- API key exists only in `chrome.storage.session` and clears on browser restart
- content requests are limited to two fixed routes and reject insecure or credential-bearing origins
- Chrome 102+ is declared for session storage support

## Validation
- `make lint`, `make test`, `make build`, `make check`, `make verify` (65 tests)
- external-directory `make check`
- `make mutations` (13 mutations killed)
- `make package-check` (6,313 entries)
- extension rendering/authentication checks
- `gitleaks detect --no-banner --no-git --source .`
- `git diff --check`

Closes #36