### PR TITLE
fix: support spaced verification paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
 
 - Install dependencies: `python -m pip install --require-hashes --only-binary=:all: -r api/requirements.txt`
 - Full baseline: `make check`
+- Make gates support absolute checkout paths containing spaces; preserve the encoded `MAKEFILE_LIST` root derivation and its recursive regression.
 - Combined verification: `make verify`
 - Lint/static checks: `make lint`
 - Tests: `make test`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 
 - Install dependencies: `python -m pip install --require-hashes --only-binary=:all: -r api/requirements.txt`
 - Full baseline: `make check`
-- Make gates support absolute checkout paths containing spaces; preserve the encoded `MAKEFILE_LIST` root derivation and its recursive regression.
+- Make gates support absolute checkout paths containing spaces; preserve the validated single-Makefile root derivation, startup-authority rejection, and recursive regression.
 - Combined verification: `make verify`
 - Lint/static checks: `make lint`
 - Tests: `make test`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,46 @@
 # Changes
 
-## 2026-06-27
+## 2026-06-26 18:30 PDT - P2 - Spaced verification paths
+
+### Summary
 
 - Made every Make gate preserve absolute checkout roots containing spaces and
   quoted both extension-rendering inputs so the full baseline preserves those
   roots. Added a recursive-safe regression that runs the full baseline from an
   external caller directory against a copied spaced-path checkout.
+
+### Files changed
+
+- `Makefile` — validated single-file root resolution and startup-authority
+  rejection.
+- `scripts/check-baseline.sh`, `scripts/check-extension-rendering.sh`, and
+  `scripts/test-make-spaced-path.py` — path-safe checks and regressions.
+- `AGENTS.md`, `README.md`, and
+  `docs/plans/2026-06-13-location-independent-make.md` — synchronized contract.
+
+### Validation
+
+- The prior root expression failed from spaced checkouts; the extension checker
+  separately split its two source paths.
+- Exact hosted gates cover all 65 API tests, extension rendering/authentication,
+  package boundaries, the recursive spaced-path check, and CodeQL.
+- Local parser probes confirm exact spaced-root resolution and fail-closed
+  `MAKEFILES`/`MAKEFILE_LIST` handling.
+
+### Bugs / findings
+
+- Sentinel replacement also collapsed separators between multiple loaded
+  Makefiles, producing a concatenated false root. The final resolver requires
+  one authoritative Makefile instead of guessing.
+
+### Blockers
+
+- Dependency-backed Chalice package construction remains hosted because the
+  local environment does not provide `chalice`.
+
+### Next action
+
+- Re-run all hosted gates on the corrected exact head and merge only when green.
 
 ## 2026-06-26T23:40:00Z
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,8 @@
 
 - Dependency-backed Chalice package construction remains hosted because the
   local environment does not provide `chalice`.
+- `codex review --base origin/main` returned HTTP 401 before analysis; the
+  authentication-only review attempt was skipped after one invocation.
 
 ### Next action
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2026-06-27
+
+- Made every Make gate preserve absolute checkout roots containing spaces and
+  quoted both extension-rendering inputs so the full baseline preserves those
+  roots. Added a recursive-safe regression that runs the full baseline from an
+  external caller directory against a copied spaced-path checkout.
+
 ## 2026-06-26T23:40:00Z
 
 - **Priority:** P0 authentication compatibility and credential containment.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 .PHONY: build check compile lint mutations package-check test verify
 
-override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+override empty :=
+override space := $(empty) $(empty)
+override makefile_space := __GPT_DOCS_API_MAKEFILE_SPACE__
+override encoded_makefile_list := $(patsubst $(makefile_space)%,%,$(subst $(space),$(makefile_space),$(MAKEFILE_LIST)))
+override ROOT := $(subst $(makefile_space),$(space),$(abspath $(dir $(lastword $(encoded_makefile_list)))))
 
 lint: check
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
 .PHONY: build check compile lint mutations package-check test verify
 
-override empty :=
-override space := $(empty) $(empty)
-override makefile_space := __GPT_DOCS_API_MAKEFILE_SPACE__
-override encoded_makefile_list := $(patsubst $(makefile_space)%,%,$(subst $(space),$(makefile_space),$(MAKEFILE_LIST)))
-override ROOT := $(subst $(makefile_space),$(space),$(abspath $(dir $(lastword $(encoded_makefile_list)))))
+ifneq ($(strip $(MAKEFILES)),)
+$(error MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone)
+endif
+ifneq ($(origin MAKEFILE_LIST),file)
+$(error MAKEFILE_LIST must not be overridden)
+endif
+override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /usr/bin/sed 's/^ //'); [ -f "$$path" ] || exit 1; directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P)
+ifeq ($(strip $(ROOT)),)
+$(error repository Makefile path could not be resolved)
+endif
 
 lint: check
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Every Make gate derives the checkout root from the loaded `Makefile`, so an
 absolute Makefile path can be invoked from any working directory without
 changing the test, compile, baseline, or package-verification scope, including
 when the absolute checkout path contains spaces.
+Verification rejects caller-supplied `MAKEFILES` and `MAKEFILE_LIST` authority
+instead of guessing a repository root from multiple loaded files.
 `make lint` runs `scripts/check-baseline.sh`, `make test` runs deterministic
 unit tests without live OpenAI, Pinecone, AWS, or Twilio credentials, and
 `make build` compiles the Chalice app and helper modules. `make verify` keeps

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ make verify
 
 Every Make gate derives the checkout root from the loaded `Makefile`, so an
 absolute Makefile path can be invoked from any working directory without
-changing the test, compile, baseline, or package-verification scope.
+changing the test, compile, baseline, or package-verification scope, including
+when the absolute checkout path contains spaces.
 `make lint` runs `scripts/check-baseline.sh`, `make test` runs deterministic
 unit tests without live OpenAI, Pinecone, AWS, or Twilio credentials, and
 `make build` compiles the Chalice app and helper modules. `make verify` keeps

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -17,8 +17,8 @@ dependencies, deployment ownership, and credential boundaries.
 
 ## Scope
 
-1. Derive the repository root from an encoded `MAKEFILE_LIST` that preserves
-   spaces in the loaded Makefile path.
+1. Resolve one validated loaded Makefile as a whole path without Make list
+   tokenization and reject startup-variable authority injection.
 2. Run test and compile commands from that root.
 3. Invoke baseline and Chalice package checkers through rooted paths.
 4. Preserve quoted extension-rendering source paths inside the baseline.
@@ -43,8 +43,9 @@ caller-relative recipes; no runtime state or persistent migration exists.
 
 ## Work Completed
 
-- Derived `ROOT` from a sentinel-encoded loaded `Makefile` path and anchored
-  test and compile recipes to that directory, including paths with spaces.
+- Derived `ROOT` from one shell-quoted, validated loaded `Makefile` path and
+  anchored test and compile recipes to that directory, including paths with
+  spaces. `MAKEFILES` and overridden `MAKEFILE_LIST` fail before recipes run.
 - Invoked baseline and Chalice package verification through absolute rooted
   script paths.
 - Added baseline contracts for the rooted command surface, completed plan

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -4,9 +4,9 @@ status: completed
 
 ## Context
 
-The maintained baseline passes from the checkout but Make targets fail when
-the absolute Makefile is invoked from another working directory. Test,
-compile, checker, and packaging paths are caller-relative.
+The maintained baseline originally passed only from the checkout. Rooted
+recipes later supported external callers, but GNU Make still split an absolute
+Makefile path containing spaces before deriving the checkout root.
 
 ## Priority
 
@@ -17,11 +17,14 @@ dependencies, deployment ownership, and credential boundaries.
 
 ## Scope
 
-1. Derive the repository root from `MAKEFILE_LIST`.
+1. Derive the repository root from an encoded `MAKEFILE_LIST` that preserves
+   spaces in the loaded Makefile path.
 2. Run test and compile commands from that root.
 3. Invoke baseline and Chalice package checkers through rooted paths.
-4. Add completed-plan, external-run, guidance, and hostile-mutation contracts.
-5. Preserve API, extension, dependency, IAM, Vercel, and workflow files.
+4. Preserve quoted extension-rendering source paths inside the baseline.
+5. Add a recursive-safe full-baseline regression for spaced checkout paths,
+   completed-plan, external-run, guidance, and hostile-mutation contracts.
+6. Preserve API, dependency, IAM, Vercel, and workflow files.
 
 ## Verification Plan
 
@@ -40,12 +43,14 @@ caller-relative recipes; no runtime state or persistent migration exists.
 
 ## Work Completed
 
-- Derived `ROOT` from the loaded `Makefile` and anchored test and compile
-  recipes to that directory.
+- Derived `ROOT` from a sentinel-encoded loaded `Makefile` path and anchored
+  test and compile recipes to that directory, including paths with spaces.
 - Invoked baseline and Chalice package verification through absolute rooted
   script paths.
 - Added baseline contracts for the rooted command surface, completed plan
-  evidence, and operator guidance.
+  evidence, operator guidance, and a recursive-safe spaced-path full gate.
+- Quoted both extension-rendering source paths so that checker no longer splits
+  a checkout root containing spaces.
 - Documented external-directory behavior in the README and changelog without
   changing API, cache, extension, dependency, IAM, deployment, or workflow
   behavior.
@@ -55,6 +60,8 @@ caller-relative recipes; no runtime state or persistent migration exists.
 - Root and external-directory Make gates passed for `test`, `compile`,
   `check`, `lint`, `build`, and `verify`; each test-bearing gate ran all 46 API
   tests without live credentials.
+- Spaced-checkout `make check` passed under GNU Make 4.2 and 4.4 from an
+  external caller directory, including the full API and extension baseline.
 - Local package-check reached the explicit Chalice availability guard
   and exited before package construction because the `chalice` command is not
   installed in this checkout environment. The unchanged hosted workflow owns

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -60,6 +60,7 @@ PACKAGE_SIGNAL_PLAN="$ROOT_DIR/docs/plans/2026-06-18-chalice-package-signal-forw
 EXTENSION_AUTH_DESIGN="$ROOT_DIR/docs/plans/2026-06-26-extension-client-auth-design.md"
 EXTENSION_AUTH_PLAN="$ROOT_DIR/docs/plans/2026-06-26-extension-client-auth.md"
 EXTENSION_AUTH_CHECK="$ROOT_DIR/scripts/check-extension-auth.sh"
+MAKE_SPACED_PATH_CHECK="$ROOT_DIR/scripts/test-make-spaced-path.py"
 SYNTAX_CHECK="$ROOT_DIR/scripts/check-python-syntax.py"
 
 require_file() {
@@ -136,6 +137,7 @@ for path in \
   "scripts/check-dependency-lock.py" \
   "scripts/check-extension-rendering.sh" \
   "scripts/check-extension-auth.sh" \
+  "scripts/test-make-spaced-path.py" \
   "scripts/test-extension-auth-mutations.py" \
   "scripts/verify-chalice-package.sh" \
   "scripts/check-baseline.sh"; do
@@ -199,13 +201,25 @@ for target in "lint:" "test:" "build: compile" "compile:" "check:" "package-chec
 done
 
 for make_contract in \
-  'override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))' \
+  'override makefile_space := __GPT_DOCS_API_MAKEFILE_SPACE__' \
+  'override encoded_makefile_list := $(patsubst $(makefile_space)%,%,$(subst $(space),$(makefile_space),$(MAKEFILE_LIST)))' \
+  'override ROOT := $(subst $(makefile_space),$(space),$(abspath $(dir $(lastword $(encoded_makefile_list)))))' \
   'cd "$(ROOT)" && PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=api python -m unittest discover -s api/tests' \
   'cd "$(ROOT)" && python "$(ROOT)/scripts/check-python-syntax.py" api/app.py api/chalicelib api/tests' \
   '"$(ROOT)/scripts/check-baseline.sh"' \
   '"$(ROOT)/scripts/verify-chalice-package.sh"'; do
   if ! grep -Fq "$make_contract" "$MAKEFILE"; then
     printf '%s\n' "Makefile must preserve location-independent command: $make_contract" >&2
+    exit 1
+  fi
+done
+
+for rendering_path_contract in \
+  '"$ROOT_DIR/chrome_extension/content.js"' \
+  '"$ROOT_DIR/api/chalicelib/public/content.js"' \
+  'for file in "$@"; do'; do
+  if ! grep -Fq "$rendering_path_contract" "$EXTENSION_RENDERING_CHECK"; then
+    printf '%s\n' "Extension rendering checks must preserve spaced paths: $rendering_path_contract" >&2
     exit 1
   fi
 done
@@ -1324,6 +1338,7 @@ PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="$ROOT_DIR/api" python -m unittest discover
 python "$SYNTAX_CHECK" "$ROOT_DIR/api/app.py" "$ROOT_DIR/api/chalicelib" "$ROOT_DIR/api/tests"
 "$EXTENSION_RENDERING_CHECK"
 "$EXTENSION_AUTH_CHECK"
+PYTHONDONTWRITEBYTECODE=1 python "$MAKE_SPACED_PATH_CHECK"
 
 generated_python_artifacts=$(
   find "$ROOT_DIR" \

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -201,9 +201,10 @@ for target in "lint:" "test:" "build: compile" "compile:" "check:" "package-chec
 done
 
 for make_contract in \
-  'override makefile_space := __GPT_DOCS_API_MAKEFILE_SPACE__' \
-  'override encoded_makefile_list := $(patsubst $(makefile_space)%,%,$(subst $(space),$(makefile_space),$(MAKEFILE_LIST)))' \
-  'override ROOT := $(subst $(makefile_space),$(space),$(abspath $(dir $(lastword $(encoded_makefile_list)))))' \
+  'MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone' \
+  'MAKEFILE_LIST must not be overridden' \
+  'override ROOT := $(shell path=' \
+  'repository Makefile path could not be resolved' \
   'cd "$(ROOT)" && PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=api python -m unittest discover -s api/tests' \
   'cd "$(ROOT)" && python "$(ROOT)/scripts/check-python-syntax.py" api/app.py api/chalicelib api/tests' \
   '"$(ROOT)/scripts/check-baseline.sh"' \

--- a/scripts/check-extension-rendering.sh
+++ b/scripts/check-extension-rendering.sh
@@ -2,12 +2,11 @@
 set -eu
 
 ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
-FILES="
-$ROOT_DIR/chrome_extension/content.js
-$ROOT_DIR/api/chalicelib/public/content.js
-"
+set -- \
+  "$ROOT_DIR/chrome_extension/content.js" \
+  "$ROOT_DIR/api/chalicelib/public/content.js"
 
-for file in $FILES; do
+for file in "$@"; do
   if grep -Fq 'innerHTML' "$file"; then
     printf '%s\n' "$file must not render content with innerHTML." >&2
     exit 1

--- a/scripts/test-make-spaced-path.py
+++ b/scripts/test-make-spaced-path.py
@@ -10,6 +10,17 @@ ROOT = Path(__file__).resolve().parents[1]
 CHILD_MARKER = "GPT_DOCS_API_MAKE_SPACE_CHILD"
 
 
+def make_command(make, copied_root, caller_root, *arguments, environment=None):
+    return subprocess.run(
+        [make, "--no-print-directory", "-f", str(copied_root / "Makefile"), *arguments],
+        cwd=caller_root,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+
 def main():
     if os.environ.get(CHILD_MARKER) == "1":
         return
@@ -35,10 +46,39 @@ def main():
         )
 
         environment = os.environ.copy()
+        make = environment.get("GPT_DOCS_API_MAKE", "make")
+        root_result = make_command(
+            make,
+            copied_root,
+            caller_root,
+            "--eval",
+            'print-root:;@printf "%s\\n" "$(ROOT)"',
+            "print-root",
+            environment=environment,
+        )
+        if root_result.returncode != 0 or root_result.stdout.strip() != str(copied_root.resolve()):
+            raise AssertionError("spaced Makefile invocation resolved the wrong repository root")
+
+        extra_makefile = temporary_root / "extra.mk"
+        extra_makefile.write_text("all:\n\t@:\n")
+        hostile_environment = environment.copy()
+        hostile_environment["MAKEFILES"] = str(extra_makefile)
+        hostile_result = make_command(
+            make, copied_root, caller_root, "check", environment=hostile_environment
+        )
+        if hostile_result.returncode == 0 or "MAKEFILES must be empty" not in hostile_result.stderr:
+            raise AssertionError("MAKEFILES contamination must fail closed")
+
+        list_override_result = make_command(
+            make, copied_root, caller_root, "MAKEFILE_LIST=hostile", "check", environment=environment
+        )
+        if list_override_result.returncode == 0 or "MAKEFILE_LIST must not be overridden" not in list_override_result.stderr:
+            raise AssertionError("MAKEFILE_LIST override must fail closed")
+
         environment[CHILD_MARKER] = "1"
         subprocess.run(
             [
-                environment.get("GPT_DOCS_API_MAKE", "make"),
+                make,
                 "-f",
                 str(copied_root / "Makefile"),
                 "check",

--- a/scripts/test-make-spaced-path.py
+++ b/scripts/test-make-spaced-path.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHILD_MARKER = "GPT_DOCS_API_MAKE_SPACE_CHILD"
+
+
+def main():
+    if os.environ.get(CHILD_MARKER) == "1":
+        return
+
+    tracked_files = subprocess.check_output(
+        ["git", "-C", str(ROOT), "ls-files", "-z"]
+    ).decode().rstrip("\0").split("\0")
+
+    with tempfile.TemporaryDirectory(prefix="gpt-docs-api-make-space-") as temporary:
+        temporary_root = Path(temporary)
+        copied_root = temporary_root / "repository with spaces"
+        caller_root = temporary_root / "external caller"
+        shutil.copytree(
+            ROOT,
+            copied_root,
+            ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc", "*.pyo"),
+        )
+        caller_root.mkdir()
+        subprocess.run(["git", "-C", copied_root, "init", "-q"], check=True)
+        subprocess.run(
+            ["git", "-C", copied_root, "add", "-N", "--", *tracked_files],
+            check=True,
+        )
+
+        environment = os.environ.copy()
+        environment[CHILD_MARKER] = "1"
+        subprocess.run(
+            [
+                environment.get("GPT_DOCS_API_MAKE", "make"),
+                "-f",
+                str(copied_root / "Makefile"),
+                "check",
+            ],
+            cwd=caller_root,
+            env=environment,
+            check=True,
+            timeout=180,
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Make every repository verification target work when the absolute checkout path contains spaces, including the extension rendering checker, while rejecting caller attempts to change Makefile authority.

## Root Cause

At `c0b855b802af2bda8241ef477f1cce388b3009e8`, GNU Make split a spaced `MAKEFILE_LIST` path and the rendering checker separately split its source paths. The first correction sentinel-encoded spaces, but manual review reproduced a second bug: when `MAKEFILES` or another `-f` input added a makefile, sentinel replacement collapsed the file-list separator into the path and produced a concatenated false root.

## Improvements

- Resolve one shell-quoted, validated loaded Makefile as a whole path and derive its physical directory.
- Reject non-empty `MAKEFILES` and overridden `MAKEFILE_LIST` before any API, extension, or package recipe runs.
- Quote extension-rendering inputs and iterate over positional arguments.
- Copy the tracked tree into a spaced path, verify exact root resolution and hostile startup rejection, then recursively run the full baseline once.
- Synchronize Make, baseline, operator guidance, changelog, and completed-plan contracts.

## Validation

- Local exact parser probes pass for spaced-root resolution and fail-closed `MAKEFILES`/`MAKEFILE_LIST` inputs.
- Python compilation, shell syntax, and `git diff --check` pass.
- The recursive local full gate reaches the explicit dependency boundary because this environment lacks the locked `openai` package; refreshed hosted checks own the 65 API tests and dependency-backed baseline.
- The prior exact head passed both Check events and CodeQL; all required contexts must repeat on the corrected exact head before merge.
- Working, staged, and fresh-clone Gitleaks scans in the original cycle found zero leaks.

## Risk

The verification Makefile is intentionally authoritative and must be loaded alone; unsupported multi-`-f` composition now fails rather than guessing a root. API behavior, dependencies, IAM, credentials, deployment configuration, and extension runtime behavior are unchanged.

Live OpenAI, Pinecone, AWS, Twilio, browser publication, and production traffic remain outside this offline verification scope.
